### PR TITLE
New feature: support properties

### DIFF
--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -35,6 +35,9 @@ export class NavigationComponent extends Component {
 	public onload(): void {
 		this.navigation = new Navigation({
 			target: this.containerEl,
+			props: {
+				settings: this.plugin.settings,
+			},
 		});
 		this.loaded = true;
 	}
@@ -186,6 +189,7 @@ export class NavigationComponent extends Component {
 							destinationPath: linkedFile.path,
 							fileExists: true,
 							annotation: property,
+							isPropertyLink: true,
 							clickHandler: (target, e) => {
 								void this.plugin.app.workspace.openLinkText(
 									target.destinationPath!,

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -69,6 +69,7 @@ export class NavigationComponent extends Component {
 				this.getPropertyLinks(file, hoverParent)
 			]).then(([annotated, property]) => [...annotated, ...property]),
 			displayPlaceholder: this.plugin.settings?.displayPlaceholder,
+			settings: this.plugin.settings,
 		});
 	}
 

--- a/src/navigationLinkState.ts
+++ b/src/navigationLinkState.ts
@@ -21,6 +21,7 @@ export class NavigationLinkState {
 	public annotation?: string;
 	public clickHandler?: LinkEventHandler;
 	public mouseOverHandler?: LinkEventHandler;
+	public isPropertyLink?: boolean;
 
 	/**
 	 * @param enabled If `false`, this object does not represent a valid navigation link,
@@ -28,6 +29,7 @@ export class NavigationLinkState {
 	 * @param destinationPath The path to the destination file. This must be normalized beforehand.
 	 * @param fileExists Whether the destination file exists in the vault.
 	 * @param annotation The annotation string.
+	 * @param isPropertyLink Whether this link is extracted from a property.
 	 */
 	constructor({
 		enabled,
@@ -36,6 +38,7 @@ export class NavigationLinkState {
 		annotation,
 		clickHandler,
 		mouseOverHandler,
+		isPropertyLink,
 	}: {
 		enabled: boolean;
 		destinationPath?: string;
@@ -43,6 +46,7 @@ export class NavigationLinkState {
 		annotation?: string;
 		clickHandler?: LinkEventHandler;
 		mouseOverHandler?: LinkEventHandler;
+		isPropertyLink?: boolean;
 	}) {
 		this.enabled = enabled;
 		this.destinationPath = destinationPath;
@@ -50,6 +54,7 @@ export class NavigationLinkState {
 		this.annotation = annotation;
 		this.clickHandler = clickHandler;
 		this.mouseOverHandler = mouseOverHandler;
+		this.isPropertyLink = isPropertyLink;
 	}
 
 	/**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,7 +15,7 @@ export interface NavLinkHeaderSettings {
 	displayPlaceholder: boolean;
 	confirmFileCreation: boolean;
 	upLinkProperties: string;
-	metadataLinkEmoji: string;
+	propertyLinkEmoji: string;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -32,7 +32,7 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	displayPlaceholder: false,
 	confirmFileCreation: true,
 	upLinkProperties: "up",
-	metadataLinkEmoji: "🔗",
+	propertyLinkEmoji: "⬆️",
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -241,23 +241,35 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Up link properties")
-			.setDesc("Specify the properties to display for up links.")
+			.setDesc(
+				"Define the properties to use for up links. " +
+					"To specify multiple properties, separate them with commas."
+			)
 			.addText((text) => {
 				text.setValue(this.plugin.settings!.upLinkProperties).onChange(
 					async (value) => {
 						this.plugin.settings!.upLinkProperties = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
 						await this.plugin.saveSettings();
 					}
 				);
 			});
 
 		new Setting(containerEl)
-			.setName("Metadata link emoji")
-			.setDesc("Specify the emoji to display for metadata links.")
+			.setName("Property link emoji")
+			.setDesc(
+				"The emoji to display for property links. " +
+					"This will replace the property name in the navigation."
+			)
 			.addText((text) => {
-				text.setValue(this.plugin.settings!.metadataLinkEmoji).onChange(
+				text.setValue(this.plugin.settings!.propertyLinkEmoji).onChange(
 					async (value) => {
-						this.plugin.settings!.metadataLinkEmoji = value;
+						this.plugin.settings!.propertyLinkEmoji = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
 						await this.plugin.saveSettings();
 					}
 				);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,8 @@ export interface NavLinkHeaderSettings {
 	yearlyNoteLinksEnabled: boolean;
 	displayPlaceholder: boolean;
 	confirmFileCreation: boolean;
+	upLinkProperties: string;
+	metadataLinkEmoji: string;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -29,6 +31,8 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	yearlyNoteLinksEnabled: false,
 	displayPlaceholder: false,
 	confirmFileCreation: true,
+	upLinkProperties: "up",
+	metadataLinkEmoji: "🔗",
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -233,6 +237,30 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 						this.plugin.settings!.confirmFileCreation = value;
 						await this.plugin.saveSettings();
 					});
+			});
+
+		new Setting(containerEl)
+			.setName("Up link properties")
+			.setDesc("Specify the properties to display for up links.")
+			.addText((text) => {
+				text.setValue(this.plugin.settings!.upLinkProperties).onChange(
+					async (value) => {
+						this.plugin.settings!.upLinkProperties = value;
+						await this.plugin.saveSettings();
+					}
+				);
+			});
+
+		new Setting(containerEl)
+			.setName("Metadata link emoji")
+			.setDesc("Specify the emoji to display for metadata links.")
+			.addText((text) => {
+				text.setValue(this.plugin.settings!.metadataLinkEmoji).onChange(
+					async (value) => {
+						this.plugin.settings!.metadataLinkEmoji = value;
+						await this.plugin.saveSettings();
+					}
+				);
 			});
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface NavLinkHeaderSettings {
 	confirmFileCreation: boolean;
 	upLinkProperties: string;
 	propertyLinkEmoji: string;
+	filterDuplicateNotes: boolean;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -33,6 +34,7 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	confirmFileCreation: true,
 	upLinkProperties: "up",
 	propertyLinkEmoji: "⬆️",
+	filterDuplicateNotes: true,
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -273,6 +275,21 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}
 				);
+			});
+
+		new Setting(containerEl)
+			.setName("Filter duplicate notes")
+			.setDesc("Filter out duplicate notes in the navigation.")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings!.filterDuplicateNotes)
+					.onChange(async (value) => {
+						this.plugin.settings!.filterDuplicateNotes = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
+						await this.plugin.saveSettings();
+					});
 			});
 	}
 }

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -4,11 +4,13 @@
 		type PeriodicNoteLinkStates,
 	} from "../navigationLinkState";
 	import { NavLinkHeaderError, type AsyncValue } from "../utils";
+	import type { NavLinkHeaderSettings } from "../settings";
 	import Icon from "./Icon.svelte";
 	import NavigationLink from "./NavigationLink.svelte";
 
 	// `undefined` is used to indicate that the entire periodic note links are disabled.
 	export let periodicNoteLinks: PeriodicNoteLinkStates | undefined;
+	export let settings: NavLinkHeaderSettings;
 
 	// The input of annotated links.
 	// Receives a promise and sets the value to `AsyncValue` when the promise is resolved.
@@ -61,19 +63,19 @@
 		<div class="container">
 			{#if periodicNoteLinks}
 				<Icon iconId="chevrons-left" />
-				<NavigationLink state={periodicNoteLinks.previous} />
+				<NavigationLink state={periodicNoteLinks.previous} {...settings} />
 				<span>||</span>
 				{#if periodicNoteLinks.up.enabled}
-					<NavigationLink state={periodicNoteLinks.up} />
+					<NavigationLink state={periodicNoteLinks.up} {...settings} />
 					<span>||</span>
 				{/if}
-				<NavigationLink state={periodicNoteLinks.next} />
+				<NavigationLink state={periodicNoteLinks.next} {...settings} />
 				<Icon iconId="chevrons-right" />
 			{/if}
 			{#if annotatedLinks.hasValue && annotatedLinks.value}
 				{#each annotatedLinks.value as link}
 					<span class="annotated-link">
-						<NavigationLink state={link} />
+						<NavigationLink state={link} {...settings} />
 					</span>
 				{/each}
 			{:else if displayPlaceholder}

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -63,19 +63,19 @@
 		<div class="container">
 			{#if periodicNoteLinks}
 				<Icon iconId="chevrons-left" />
-				<NavigationLink state={periodicNoteLinks.previous} {...settings} />
+				<NavigationLink state={periodicNoteLinks.previous} {settings} />
 				<span>||</span>
 				{#if periodicNoteLinks.up.enabled}
-					<NavigationLink state={periodicNoteLinks.up} {...settings} />
+					<NavigationLink state={periodicNoteLinks.up} {settings} />
 					<span>||</span>
 				{/if}
-				<NavigationLink state={periodicNoteLinks.next} {...settings} />
+				<NavigationLink state={periodicNoteLinks.next} {settings} />
 				<Icon iconId="chevrons-right" />
 			{/if}
 			{#if annotatedLinks.hasValue && annotatedLinks.value}
 				{#each annotatedLinks.value as link}
 					<span class="annotated-link">
-						<NavigationLink state={link} {...settings} />
+						<NavigationLink state={link} {settings} />
 					</span>
 				{/each}
 			{:else if displayPlaceholder}

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -46,6 +46,14 @@
 		!periodicNoteLinks &&
 		annotatedLinks.hasValue &&
 		annotatedLinks.value!.length === 0;
+
+	$: filteredAnnotatedLinks = settings?.filterDuplicateNotes
+		? annotatedLinks.value?.filter((link, index) => {
+			// 只保留第一次出现的笔记
+			if (!link.destinationPath) return true;
+			return annotatedLinks.value?.findIndex(l => l.destinationPath === link.destinationPath) === index;
+		})
+		: annotatedLinks.value;
 </script>
 
 <!--
@@ -72,8 +80,8 @@
 				<NavigationLink state={periodicNoteLinks.next} {settings} />
 				<Icon iconId="chevrons-right" />
 			{/if}
-			{#if annotatedLinks.hasValue && annotatedLinks.value}
-				{#each annotatedLinks.value as link}
+			{#if filteredAnnotatedLinks}
+				{#each filteredAnnotatedLinks as link}
 					<span class="annotated-link">
 						<NavigationLink state={link} {settings} />
 					</span>

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { NavigationLinkState } from "../navigationLinkState";
 	import Icon from "./Icon.svelte";
+	import type { NavLinkHeaderSettings } from "../settings";
 
 	export let state: NavigationLinkState;
+	export let settings: NavLinkHeaderSettings;
 </script>
 
 <!--
@@ -14,7 +16,7 @@
 -->
 {#if state.enabled}
 	{#if state.annotation}
-		<span>{state.annotation}</span>
+		<span>{settings?.propertyLinkEmoji || "🔗"}</span>
 	{/if}
 	<a
 		class:non-existent={!state.fileExists}

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -16,7 +16,11 @@
 -->
 {#if state.enabled}
 	{#if state.annotation}
-		<span>{settings?.propertyLinkEmoji || "🔗"}</span>
+		{#if state.isPropertyLink}
+			<span>{settings?.propertyLinkEmoji || "⬆️"}</span>
+		{:else}
+			<span>{state.annotation}</span>
+		{/if}
 	{/if}
 	<a
 		class:non-existent={!state.fileExists}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,6 +58,8 @@ export function joinPaths(path1: string, path2: string): string {
 
 /**
  * Removes YAML front matter, code blocks and inline code from the note content.
+ * @param content The content to remove code from.
+ * @returns The content without code.
  */
 export function removeCode(content: string): string {
 	return (


### PR DESCRIPTION
Hi! I've added a feature for my own needs: in addition to the extraction method (Backlink) supported by the current plugin, you can also actively add properties to create link relationships.

I'm not sure if this meets your expectations for a plugin (or if it makes it too bloated), so just try to submit a PR and decline if it doesn't seem appropriate!


Here's a brief presentation and introduction:
In the plugin settings, you can add the name of the property that can be selected:
![image](https://github.com/user-attachments/assets/a63ea5e4-8dbb-403d-b4ee-f37412e103fd)

Then, the note linked to in the corresponding property of the note will also appear at the top:
![image](https://github.com/user-attachments/assets/451bfb8a-2f36-462f-831a-6f2245232399)

