### PR TITLE
Option to change display name

### DIFF
--- a/src/annotatedLink.ts
+++ b/src/annotatedLink.ts
@@ -1,5 +1,6 @@
 import { App, TFile } from "obsidian";
 import { removeCode } from "./utils";
+import type NavLinkHeader from "./main";
 
 /**
  * Searches the annotated links from the content of the backlinks of the specified file.
@@ -84,38 +85,76 @@ export async function searchAnnotatedLinks(
  * @param app The application instance.
  * @param propertyNames The properties to search for links.
  * @param file The file to search in.
+ * @param displayPropertyName The property name to use for display value.
  * @returns The array of links with their annotations.
  */
 export async function getPropertyLinks(
 	app: App,
 	propertyNames: string[],
-	file: TFile
-): Promise<{ destinationPath: string; annotation: string }[]> {
+	file: TFile,
+	displayPropertyName?: string
+): Promise<{ destinationPath: string; annotation: string; propertyValue?: string | string[] }[]> {
 	const cache = app.metadataCache.getFileCache(file);
 	if (!cache?.frontmatter || propertyNames.length === 0) {
 		return [];
 	}
 
-	const result: { destinationPath: string; annotation: string }[] = [];
+	const result: { destinationPath: string; annotation: string; propertyValue?: string | string[] }[] = [];
 	const linkedFiles = app.metadataCache.resolvedLinks[file.path] || {};
 
-	for (const [linkedPath, _] of Object.entries(linkedFiles)) {
-		const linkedFile = app.vault.getAbstractFileByPath(linkedPath);
-		if (!(linkedFile instanceof TFile)) {
+	for (const propertyName of propertyNames) {
+		const propertyValue = cache.frontmatter[propertyName];
+		if (!propertyValue) {
 			continue;
 		}
 
-		for (const property of propertyNames) {
-			const value = cache.frontmatter[property];
-			if (!value) continue;
+		const links = Array.isArray(propertyValue)
+			? propertyValue
+			: [propertyValue];
 
-			const propertyValue = String(value);
-			if (propertyValue.includes(linkedFile.basename)) {
-				result.push({
-					destinationPath: linkedFile.path,
-					annotation: property
-				});
+		for (const link of links) {
+			if (typeof link !== "string") {
+				continue;
 			}
+
+			const linkedFile = app.metadataCache.getFirstLinkpathDest(
+				link,
+				file.path
+			);
+			if (!linkedFile || !linkedFiles[linkedFile.path]) {
+				continue;
+			}
+
+			// Get the display property value from the linked file (target)
+			const linkedFileCache = app.metadataCache.getFileCache(linkedFile);
+			let displayValue: string | string[] | undefined;
+			console.log('Debug getPropertyLinks:', {
+				linkedFile: linkedFile.path,
+				frontmatter: linkedFileCache?.frontmatter,
+				displayPropertyName,
+				hasProperty: linkedFileCache?.frontmatter && displayPropertyName 
+					? displayPropertyName in (linkedFileCache.frontmatter || {})
+					: false
+			});
+
+			// Make sure we get the title from frontmatter
+			if (linkedFileCache?.frontmatter && displayPropertyName) {
+				if (displayPropertyName === 'title' && !linkedFileCache.frontmatter['title']) {
+					// If title is not in frontmatter, use the file title
+					displayValue = linkedFile.basename;
+					console.log('Using file basename as title:', displayValue);
+				} else if (displayPropertyName in linkedFileCache.frontmatter) {
+					const value = linkedFileCache.frontmatter[displayPropertyName];
+					displayValue = value;
+					console.log('Found display value in frontmatter:', displayValue);
+				}
+			}
+
+			result.push({
+				destinationPath: linkedFile.path,
+				annotation: propertyName,
+				propertyValue: displayValue,
+			});
 		}
 	}
 

--- a/src/annotatedLink.ts
+++ b/src/annotatedLink.ts
@@ -128,25 +128,15 @@ export async function getPropertyLinks(
 			// Get the display property value from the linked file (target)
 			const linkedFileCache = app.metadataCache.getFileCache(linkedFile);
 			let displayValue: string | string[] | undefined;
-			console.log('Debug getPropertyLinks:', {
-				linkedFile: linkedFile.path,
-				frontmatter: linkedFileCache?.frontmatter,
-				displayPropertyName,
-				hasProperty: linkedFileCache?.frontmatter && displayPropertyName 
-					? displayPropertyName in (linkedFileCache.frontmatter || {})
-					: false
-			});
 
 			// Make sure we get the title from frontmatter
 			if (linkedFileCache?.frontmatter && displayPropertyName) {
 				if (displayPropertyName === 'title' && !linkedFileCache.frontmatter['title']) {
 					// If title is not in frontmatter, use the file title
 					displayValue = linkedFile.basename;
-					console.log('Using file basename as title:', displayValue);
 				} else if (displayPropertyName in linkedFileCache.frontmatter) {
 					const value = linkedFileCache.frontmatter[displayPropertyName];
 					displayValue = value;
-					console.log('Found display value in frontmatter:', displayValue);
 				}
 			}
 

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -91,6 +91,17 @@ export class NavigationComponent extends Component {
 			.map(p => p.trim())
 			.filter(p => p.length > 0) || [];
 
+		// If no annotation strings are specified, return an empty array
+		if (annotationStrings.length + propertyNames.length === 0) {
+			return [];
+		}
+
+		if (!this.loaded) {
+			throw new NavLinkHeaderError(
+				"The navigation component is not loaded."
+			);
+		}
+
 		// Get both annotated links and property links
 		const [annotatedLinks, propertyLinks] = await Promise.all([
 			searchAnnotatedLinks(

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -82,14 +82,8 @@ export class NavigationComponent extends Component {
 		}
 
 		const filePath = file.path;
-		const annotationStrings = this.plugin
-			.settings!.annotationStrings.split(",")
-			.map((s) => s.trim())
-			.filter((s) => s.length > 0);
-
-		const propertyNames = this.plugin.settings?.upLinkProperties?.split(",")
-			.map(p => p.trim())
-			.filter(p => p.length > 0) || [];
+		const annotationStrings = this.plugin.settings!.annotationStrings.split(",");
+		const propertyNames = this.plugin.settings!.propertyMappings.map(mapping => mapping.property);
 
 		// If no annotation strings are specified, return an empty array
 		if (annotationStrings.length + propertyNames.length === 0) {
@@ -101,8 +95,7 @@ export class NavigationComponent extends Component {
 				"The navigation component is not loaded."
 			);
 		}
-
-		// Get both annotated links and property links
+		
 		const [annotatedLinks, propertyLinks] = await Promise.all([
 			searchAnnotatedLinks(
 				this.plugin.app,

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -154,7 +154,7 @@ export class NavigationComponent extends Component {
 			: allLinks;
 
 		// Convert to NavigationLinkState
-		return uniqueLinks.map(
+		let linkStates = uniqueLinks.map(
 			(link) =>
 				new NavigationLinkState({
 					enabled: true,
@@ -182,7 +182,20 @@ export class NavigationComponent extends Component {
 					},
 				})
 		);
-	}
+
+		linkStates.sort((a, b) => {
+			const diff =
+				annotationStrings.indexOf(a.annotation!) -
+				annotationStrings.indexOf(b.annotation!);
+			if (diff !== 0) {
+				return diff;
+			}
+			return a.title.localeCompare(b.title);
+		});
+
+		return linkStates;
+
+	}	
 
 	private getPeriodicNoteLinkStates(
 		file: TFile,

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -109,14 +109,6 @@ export class NavigationComponent extends Component {
 			)
 		]);
 
-		console.log('Debug navigationComponent:', {
-			settings: {
-				usePropertyAsDisplayName: this.plugin.settings?.usePropertyAsDisplayName,
-				displayPropertyName: this.plugin.settings?.displayPropertyName
-			},
-			propertyLinks
-		});
-
 		// Get property values for all links if needed
 		const propertyValuesForAnnotatedLinks = this.plugin.settings?.usePropertyAsDisplayName
 			? await Promise.all(

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -35,6 +35,9 @@ export class NavigationComponent extends Component {
 	public onload(): void {
 		this.navigation = new Navigation({
 			target: this.containerEl,
+			props: {
+				settings: this.plugin.settings,
+			},
 		});
 		this.loaded = true;
 	}
@@ -186,6 +189,7 @@ export class NavigationComponent extends Component {
 							destinationPath: linkedFile.path,
 							fileExists: true,
 							annotation: property,
+							isPropertyLink: true,
 							clickHandler: (target, e) => {
 								void this.plugin.app.workspace.openLinkText(
 									target.destinationPath!,

--- a/src/navigationComponent.ts
+++ b/src/navigationComponent.ts
@@ -69,6 +69,7 @@ export class NavigationComponent extends Component {
 				this.getPropertyLinks(file, hoverParent)
 			]).then(([annotated, property]) => [...annotated, ...property]),
 			displayPlaceholder: this.plugin.settings?.displayPlaceholder,
+			settings: this.plugin.settings,
 		});
 	}
 

--- a/src/navigationLinkState.ts
+++ b/src/navigationLinkState.ts
@@ -1,6 +1,11 @@
 import { getTitleFromPath } from "./utils";
 import { TFile } from "obsidian";
 
+export type LinkEventHandler = (
+	target: NavigationLinkState,
+	e: MouseEvent
+) => void;
+
 export interface NavigationLinkStateOptions {
 	enabled: boolean;
 	destinationPath?: string;
@@ -34,6 +39,13 @@ export class NavigationLinkState {
 		e: MouseEvent
 	) => void;
 
+	/**
+	 * @param enabled If `false`, this object does not represent a valid navigation link,
+	 *     and the other properties are ignored.
+	 * @param destinationPath The path to the destination file. This must be normalized beforehand.
+	 * @param fileExists Whether the destination file exists in the vault.
+	 * @param annotation The annotation string.
+	 */
 	constructor(options: NavigationLinkStateOptions) {
 		this.enabled = options.enabled;
 		this.destinationPath = options.destinationPath;

--- a/src/navigationLinkState.ts
+++ b/src/navigationLinkState.ts
@@ -56,12 +56,6 @@ export class NavigationLinkState {
 		if (!this.destinationPath) {
 			return "";
 		}
-		console.log('NavigationLinkState displayTitle:', {
-			destinationPath: this.destinationPath,
-			propertyValue: this.propertyValue,
-			title: this.title,
-			isPropertyLink: this.isPropertyLink
-		});
 		if (this.propertyValue) {
 			if (Array.isArray(this.propertyValue)) {
 				return this.propertyValue[0] || this.title;

--- a/src/navigationLinkState.ts
+++ b/src/navigationLinkState.ts
@@ -21,6 +21,7 @@ export class NavigationLinkState {
 	public annotation?: string;
 	public clickHandler?: LinkEventHandler;
 	public mouseOverHandler?: LinkEventHandler;
+	public isPropertyLink?: boolean;
 
 	/**
 	 * @param enabled If `false`, this object does not represent a valid navigation link,
@@ -28,6 +29,7 @@ export class NavigationLinkState {
 	 * @param destinationPath The path to the destination file. This must be normalized beforehand.
 	 * @param fileExists Whether the destination file exists in the vault.
 	 * @param annotation The annotation string.
+	 * @param isPropertyLink Whether this link is extracted from a property.
 	 */
 	constructor({
 		enabled,
@@ -36,6 +38,7 @@ export class NavigationLinkState {
 		annotation,
 		clickHandler,
 		mouseOverHandler,
+		isPropertyLink,
 	}: {
 		enabled: boolean;
 		destinationPath?: string;
@@ -43,6 +46,7 @@ export class NavigationLinkState {
 		annotation?: string;
 		clickHandler?: LinkEventHandler;
 		mouseOverHandler?: LinkEventHandler;
+		isPropertyLink?: boolean;
 	}) {
 		this.enabled = enabled;
 		this.destinationPath = destinationPath;
@@ -50,6 +54,7 @@ export class NavigationLinkState {
 		this.annotation = annotation;
 		this.clickHandler = clickHandler;
 		this.mouseOverHandler = mouseOverHandler;
+		this.isPropertyLink = isPropertyLink;
 	}
 
 	/**

--- a/src/navigationLinkState.ts
+++ b/src/navigationLinkState.ts
@@ -1,15 +1,22 @@
 import { getTitleFromPath } from "./utils";
+import { TFile } from "obsidian";
 
-export type LinkEventHandler = (
-	target: NavigationLinkState,
-	e: MouseEvent
-) => void;
+export interface NavigationLinkStateOptions {
+	enabled: boolean;
+	destinationPath?: string;
+	fileExists?: boolean;
+	annotation?: string;
+	isPropertyLink?: boolean;
+	propertyValue?: string | string[];
+	clickHandler?: (target: NavigationLinkState, e: MouseEvent) => void;
+	mouseOverHandler?: (target: NavigationLinkState, e: MouseEvent) => void;
+}
 
-export type PeriodicNoteLinkStates = {
+export interface PeriodicNoteLinkStates {
 	previous: NavigationLinkState;
 	next: NavigationLinkState;
 	up: NavigationLinkState;
-};
+}
 
 /**
  * Represents a state of the `NavigationLink`.
@@ -19,50 +26,48 @@ export class NavigationLinkState {
 	public destinationPath?: string;
 	public fileExists?: boolean;
 	public annotation?: string;
-	public clickHandler?: LinkEventHandler;
-	public mouseOverHandler?: LinkEventHandler;
 	public isPropertyLink?: boolean;
+	public propertyValue?: string | string[];
+	public clickHandler?: (target: NavigationLinkState, e: MouseEvent) => void;
+	public mouseOverHandler?: (
+		target: NavigationLinkState,
+		e: MouseEvent
+	) => void;
 
-	/**
-	 * @param enabled If `false`, this object does not represent a valid navigation link,
-	 *     and the other properties are ignored.
-	 * @param destinationPath The path to the destination file. This must be normalized beforehand.
-	 * @param fileExists Whether the destination file exists in the vault.
-	 * @param annotation The annotation string.
-	 * @param isPropertyLink Whether this link is extracted from a property.
-	 */
-	constructor({
-		enabled,
-		destinationPath,
-		fileExists,
-		annotation,
-		clickHandler,
-		mouseOverHandler,
-		isPropertyLink,
-	}: {
-		enabled: boolean;
-		destinationPath?: string;
-		fileExists?: boolean;
-		annotation?: string;
-		clickHandler?: LinkEventHandler;
-		mouseOverHandler?: LinkEventHandler;
-		isPropertyLink?: boolean;
-	}) {
-		this.enabled = enabled;
-		this.destinationPath = destinationPath;
-		this.fileExists = fileExists;
-		this.annotation = annotation;
-		this.clickHandler = clickHandler;
-		this.mouseOverHandler = mouseOverHandler;
-		this.isPropertyLink = isPropertyLink;
+	constructor(options: NavigationLinkStateOptions) {
+		this.enabled = options.enabled;
+		this.destinationPath = options.destinationPath;
+		this.fileExists = options.fileExists;
+		this.annotation = options.annotation;
+		this.isPropertyLink = options.isPropertyLink;
+		this.propertyValue = options.propertyValue;
+		this.clickHandler = options.clickHandler;
+		this.mouseOverHandler = options.mouseOverHandler;
 	}
 
-	/**
-	 * The title of the destination file. The extension is not included.
-	 */
 	public get title(): string {
-		return this.destinationPath
-			? getTitleFromPath(this.destinationPath)
-			: "";
+		if (!this.destinationPath) {
+			return "";
+		}
+		return getTitleFromPath(this.destinationPath);
+	}
+
+	public get displayTitle(): string {
+		if (!this.destinationPath) {
+			return "";
+		}
+		console.log('NavigationLinkState displayTitle:', {
+			destinationPath: this.destinationPath,
+			propertyValue: this.propertyValue,
+			title: this.title,
+			isPropertyLink: this.isPropertyLink
+		});
+		if (this.propertyValue) {
+			if (Array.isArray(this.propertyValue)) {
+				return this.propertyValue[0] || this.title;
+			}
+			return this.propertyValue || this.title;
+		}
+		return this.title;
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,7 @@ export interface NavLinkHeaderSettings {
 	filterDuplicateNotes: boolean;
 	usePropertyAsDisplayName: boolean;
 	displayPropertyName: string;
+	devMode: boolean;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -39,6 +40,7 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	filterDuplicateNotes: true,
 	usePropertyAsDisplayName: false,
 	displayPropertyName: "title",
+	devMode: false,
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -336,5 +338,17 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 						);
 				});
 		}
+
+		new Setting(containerEl)
+			.setName("Development mode")
+			.setDesc("Enable development mode for debugging purposes.")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings!.devMode)
+					.onChange(async (value) => {
+						this.plugin.settings!.devMode = value;
+						await this.plugin.saveSettings();
+					});
+			});
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,7 +15,7 @@ export interface NavLinkHeaderSettings {
 	displayPlaceholder: boolean;
 	confirmFileCreation: boolean;
 	upLinkProperties: string;
-	metadataLinkEmoji: string;
+	propertyLinkEmoji: string;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -32,7 +32,7 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	displayPlaceholder: false,
 	confirmFileCreation: true,
 	upLinkProperties: "up",
-	metadataLinkEmoji: "🔗",
+	propertyLinkEmoji: "⬆️",
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -241,23 +241,35 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Up link properties")
-			.setDesc("Specify the properties to display for up links.")
+			.setDesc(
+				"Define the properties to use for up links. " +
+					"To specify multiple properties, separate them with commas."
+			)
 			.addText((text) => {
 				text.setValue(this.plugin.settings!.upLinkProperties).onChange(
 					async (value) => {
 						this.plugin.settings!.upLinkProperties = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
 						await this.plugin.saveSettings();
 					}
 				);
 			});
 
 		new Setting(containerEl)
-			.setName("Metadata link emoji")
-			.setDesc("Specify the emoji to display for metadata links.")
+			.setName("Property link emoji")
+			.setDesc(
+				"The emoji to display for property links. " +
+					"This will replace the property name in the navigation."
+			)
 			.addText((text) => {
-				text.setValue(this.plugin.settings!.metadataLinkEmoji).onChange(
+				text.setValue(this.plugin.settings!.propertyLinkEmoji).onChange(
 					async (value) => {
-						this.plugin.settings!.metadataLinkEmoji = value;
+						this.plugin.settings!.propertyLinkEmoji = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
 						await this.plugin.saveSettings();
 					}
 				);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,8 @@ export interface NavLinkHeaderSettings {
 	yearlyNoteLinksEnabled: boolean;
 	displayPlaceholder: boolean;
 	confirmFileCreation: boolean;
+	upLinkProperties: string;
+	metadataLinkEmoji: string;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -29,6 +31,8 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	yearlyNoteLinksEnabled: false,
 	displayPlaceholder: false,
 	confirmFileCreation: true,
+	upLinkProperties: "up",
+	metadataLinkEmoji: "🔗",
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -233,6 +237,30 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 						this.plugin.settings!.confirmFileCreation = value;
 						await this.plugin.saveSettings();
 					});
+			});
+
+		new Setting(containerEl)
+			.setName("Up link properties")
+			.setDesc("Specify the properties to display for up links.")
+			.addText((text) => {
+				text.setValue(this.plugin.settings!.upLinkProperties).onChange(
+					async (value) => {
+						this.plugin.settings!.upLinkProperties = value;
+						await this.plugin.saveSettings();
+					}
+				);
+			});
+
+		new Setting(containerEl)
+			.setName("Metadata link emoji")
+			.setDesc("Specify the emoji to display for metadata links.")
+			.addText((text) => {
+				text.setValue(this.plugin.settings!.metadataLinkEmoji).onChange(
+					async (value) => {
+						this.plugin.settings!.metadataLinkEmoji = value;
+						await this.plugin.saveSettings();
+					}
+				);
 			});
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface NavLinkHeaderSettings {
 	confirmFileCreation: boolean;
 	upLinkProperties: string;
 	propertyLinkEmoji: string;
+	filterDuplicateNotes: boolean;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -33,6 +34,7 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	confirmFileCreation: true,
 	upLinkProperties: "up",
 	propertyLinkEmoji: "⬆️",
+	filterDuplicateNotes: true,
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -273,6 +275,21 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}
 				);
+			});
+
+		new Setting(containerEl)
+			.setName("Filter duplicate notes")
+			.setDesc("Filter out duplicate notes in the navigation.")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings!.filterDuplicateNotes)
+					.onChange(async (value) => {
+						this.plugin.settings!.filterDuplicateNotes = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
+						await this.plugin.saveSettings();
+					});
 			});
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,8 @@ export interface NavLinkHeaderSettings {
 	upLinkProperties: string;
 	propertyLinkEmoji: string;
 	filterDuplicateNotes: boolean;
+	usePropertyAsDisplayName: boolean;
+	displayPropertyName: string;
 }
 
 export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
@@ -35,6 +37,8 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 	upLinkProperties: "up",
 	propertyLinkEmoji: "⬆️",
 	filterDuplicateNotes: true,
+	usePropertyAsDisplayName: false,
+	displayPropertyName: "title",
 };
 
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
@@ -291,5 +295,46 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					});
 			});
+
+		new Setting(containerEl)
+			.setName("Use property as display name")
+			.setDesc(
+				"Use the property value as the display name for property links."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings!.usePropertyAsDisplayName)
+					.onChange(async (value) => {
+						this.plugin.settings!.usePropertyAsDisplayName = value;
+						this.plugin.app.workspace.trigger(
+							"nav-link-header:settings-changed"
+						);
+						await this.plugin.saveSettings();
+						// Force refresh the settings panel to show/hide the property name setting
+						this.display();
+					});
+			});
+
+		if (this.plugin.settings!.usePropertyAsDisplayName) {
+			new Setting(containerEl)
+				.setName("Display property name")
+				.setDesc(
+					"The property name to display for property links. " +
+						"If left blank, the property name will not be displayed."
+				)
+				.addText((text) => {
+					text
+						.setValue(this.plugin.settings!.displayPropertyName)
+						.onChange(
+							async (value) => {
+								this.plugin.settings!.displayPropertyName = value;
+								this.plugin.app.workspace.trigger(
+									"nav-link-header:settings-changed"
+								);
+								await this.plugin.saveSettings();
+							}
+						);
+				});
+		}
 	}
 }

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -4,11 +4,13 @@
 		type PeriodicNoteLinkStates,
 	} from "../navigationLinkState";
 	import { NavLinkHeaderError, type AsyncValue } from "../utils";
+	import type { NavLinkHeaderSettings } from "../settings";
 	import Icon from "./Icon.svelte";
 	import NavigationLink from "./NavigationLink.svelte";
 
 	// `undefined` is used to indicate that the entire periodic note links are disabled.
 	export let periodicNoteLinks: PeriodicNoteLinkStates | undefined;
+	export let settings: NavLinkHeaderSettings;
 
 	// The input of annotated links.
 	// Receives a promise and sets the value to `AsyncValue` when the promise is resolved.
@@ -61,19 +63,19 @@
 		<div class="container">
 			{#if periodicNoteLinks}
 				<Icon iconId="chevrons-left" />
-				<NavigationLink state={periodicNoteLinks.previous} />
+				<NavigationLink state={periodicNoteLinks.previous} {...settings} />
 				<span>||</span>
 				{#if periodicNoteLinks.up.enabled}
-					<NavigationLink state={periodicNoteLinks.up} />
+					<NavigationLink state={periodicNoteLinks.up} {...settings} />
 					<span>||</span>
 				{/if}
-				<NavigationLink state={periodicNoteLinks.next} />
+				<NavigationLink state={periodicNoteLinks.next} {...settings} />
 				<Icon iconId="chevrons-right" />
 			{/if}
 			{#if annotatedLinks.hasValue && annotatedLinks.value}
 				{#each annotatedLinks.value as link}
 					<span class="annotated-link">
-						<NavigationLink state={link} />
+						<NavigationLink state={link} {...settings} />
 					</span>
 				{/each}
 			{:else if displayPlaceholder}

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -63,19 +63,19 @@
 		<div class="container">
 			{#if periodicNoteLinks}
 				<Icon iconId="chevrons-left" />
-				<NavigationLink state={periodicNoteLinks.previous} {...settings} />
+				<NavigationLink state={periodicNoteLinks.previous} {settings} />
 				<span>||</span>
 				{#if periodicNoteLinks.up.enabled}
-					<NavigationLink state={periodicNoteLinks.up} {...settings} />
+					<NavigationLink state={periodicNoteLinks.up} {settings} />
 					<span>||</span>
 				{/if}
-				<NavigationLink state={periodicNoteLinks.next} {...settings} />
+				<NavigationLink state={periodicNoteLinks.next} {settings} />
 				<Icon iconId="chevrons-right" />
 			{/if}
 			{#if annotatedLinks.hasValue && annotatedLinks.value}
 				{#each annotatedLinks.value as link}
 					<span class="annotated-link">
-						<NavigationLink state={link} {...settings} />
+						<NavigationLink state={link} {settings} />
 					</span>
 				{/each}
 			{:else if displayPlaceholder}

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -46,6 +46,14 @@
 		!periodicNoteLinks &&
 		annotatedLinks.hasValue &&
 		annotatedLinks.value!.length === 0;
+
+	$: filteredAnnotatedLinks = settings?.filterDuplicateNotes
+		? annotatedLinks.value?.filter((link, index) => {
+			// 只保留第一次出现的笔记
+			if (!link.destinationPath) return true;
+			return annotatedLinks.value?.findIndex(l => l.destinationPath === link.destinationPath) === index;
+		})
+		: annotatedLinks.value;
 </script>
 
 <!--
@@ -72,8 +80,8 @@
 				<NavigationLink state={periodicNoteLinks.next} {settings} />
 				<Icon iconId="chevrons-right" />
 			{/if}
-			{#if annotatedLinks.hasValue && annotatedLinks.value}
-				{#each annotatedLinks.value as link}
+			{#if filteredAnnotatedLinks}
+				{#each filteredAnnotatedLinks as link}
 					<span class="annotated-link">
 						<NavigationLink state={link} {settings} />
 					</span>

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -5,6 +5,14 @@
 
 	export let state: NavigationLinkState;
 	export let settings: NavLinkHeaderSettings;
+
+	$: console.log('NavigationLink Debug:', {
+		usePropertyAsDisplayName: settings?.usePropertyAsDisplayName,
+		isPropertyLink: state.isPropertyLink,
+		propertyValue: state.propertyValue,
+		displayTitle: state.displayTitle,
+		title: state.title
+	});
 </script>
 
 <!--
@@ -31,7 +39,7 @@
 		on:mouseover={(e) => {
 			state.mouseOverHandler?.(state, e);
 		}}
-		on:focus={() => {}}>{state.title}</a
+		on:focus={() => {}}>{settings?.usePropertyAsDisplayName && state.propertyValue ? state.displayTitle : state.title}</a
 	>
 {:else}
 	<Icon iconId="minus" muted />

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -29,7 +29,11 @@
 {#if state.enabled}
 	{#if state.annotation}
 		{#if state.isPropertyLink}
-			<span>{settings?.propertyLinkEmoji || "⬆️"}</span>
+			{#each settings?.propertyMappings || [] as mapping}
+				{#if mapping.property === state.annotation}
+					<span>{mapping.emoji || "⬆️"}</span>
+				{/if}
+			{/each}
 		{:else}
 			<span>{state.annotation}</span>
 		{/if}

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { NavigationLinkState } from "../navigationLinkState";
 	import Icon from "./Icon.svelte";
+	import type { NavLinkHeaderSettings } from "../settings";
 
 	export let state: NavigationLinkState;
+	export let settings: NavLinkHeaderSettings;
 </script>
 
 <!--
@@ -14,7 +16,7 @@
 -->
 {#if state.enabled}
 	{#if state.annotation}
-		<span>{state.annotation}</span>
+		<span>{settings?.propertyLinkEmoji || "🔗"}</span>
 	{/if}
 	<a
 		class:non-existent={!state.fileExists}

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -5,14 +5,6 @@
 
 	export let state: NavigationLinkState;
 	export let settings: NavLinkHeaderSettings;
-
-	$: console.log('NavigationLink Debug:', {
-		usePropertyAsDisplayName: settings?.usePropertyAsDisplayName,
-		isPropertyLink: state.isPropertyLink,
-		propertyValue: state.propertyValue,
-		displayTitle: state.displayTitle,
-		title: state.title
-	});
 </script>
 
 <!--
@@ -34,7 +26,24 @@
 		class:non-existent={!state.fileExists}
 		href="#top"
 		on:click={(e) => {
+			e.preventDefault();
 			state.clickHandler?.(state, e);
+		}}
+		on:mousedown={(e) => {
+			// 阻止中键点击的默认滚动行为
+			if (e.button === 1) {
+				e.preventDefault();
+			}
+		}}
+		on:auxclick={(e) => {
+			// 处理中键点击，模拟 Ctrl+点击行为
+			if (e.button === 1) {
+				const simulatedEvent = new MouseEvent('click', {
+					...e,
+					ctrlKey: true
+				});
+				state.clickHandler?.(state, simulatedEvent);
+			}
 		}}
 		on:mouseover={(e) => {
 			state.mouseOverHandler?.(state, e);

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
 	import { NavigationLinkState } from "../navigationLinkState";
+	import { Debug } from "../utils/debug";
 	import Icon from "./Icon.svelte";
 	import type { NavLinkHeaderSettings } from "../settings";
 
 	export let state: NavigationLinkState;
 	export let settings: NavLinkHeaderSettings;
+
+	$: {
+		Debug.init(settings);
+		Debug.log('NavigationLink', {
+			usePropertyAsDisplayName: settings?.usePropertyAsDisplayName,
+			isPropertyLink: state.isPropertyLink,
+			propertyValue: state.propertyValue,
+			displayTitle: state.displayTitle,
+			title: state.title
+		});
+	}
 </script>
 
 <!--

--- a/src/ui/NavigationLink.svelte
+++ b/src/ui/NavigationLink.svelte
@@ -16,7 +16,11 @@
 -->
 {#if state.enabled}
 	{#if state.annotation}
-		<span>{settings?.propertyLinkEmoji || "🔗"}</span>
+		{#if state.isPropertyLink}
+			<span>{settings?.propertyLinkEmoji || "⬆️"}</span>
+		{:else}
+			<span>{state.annotation}</span>
+		{/if}
 	{/if}
 	<a
 		class:non-existent={!state.fileExists}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,6 +58,8 @@ export function joinPaths(path1: string, path2: string): string {
 
 /**
  * Removes YAML front matter, code blocks and inline code from the note content.
+ * @param content The content to remove code from.
+ * @returns The content without code.
  */
 export function removeCode(content: string): string {
 	return (

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,15 @@
+import type { NavLinkHeaderSettings } from '../settings';
+
+export class Debug {
+    private static settings: NavLinkHeaderSettings | null = null;
+
+    public static init(settings: NavLinkHeaderSettings) {
+        this.settings = settings;
+    }
+
+    public static log(context: string, data?: any) {
+        if (this.settings?.devMode) {
+            console.log(`[NavLinkHeader][${context}]:`, data);
+        }
+    }
+}


### PR DESCRIPTION
I added another option, which support display property (like `title`) rather than the original note name:
![image](https://github.com/user-attachments/assets/8d515955-e2fc-4f74-8bc6-7b9814017c8e)

For example:
![image](https://github.com/user-attachments/assets/64c97902-4ed1-4bff-b23d-cdccdc19a8f0)

This `2-Area.md` note will display as its title:
![image](https://github.com/user-attachments/assets/828001fa-9c40-47a8-9132-0e24f9fdeb9d)
