### PR TITLE
feat: Add Chinese (zh-CN) localization and redesign settings UI

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,15 +5,18 @@ import { PeriodicNotesManager } from "./periodicNotes";
 import { getThreeWayPropertyLink } from "./propertyLink";
 import { FolderLinksManager } from "./folderLink";
 import { openExternalLink } from "./utils";
+import { t } from "./i18n/i18n";
 
 /**
  * Adds commands to the plugin.
  * @param plugin The plugin instance.
  */
 export function addCommands(plugin: NavLinkHeader): void {
+  const msg = t().command;
+
   plugin.addCommand({
     id: "open-previous-property-link",
-    name: "Open previous property link",
+    name: msg.openPreviousPropertyLink,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -25,7 +28,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-next-property-link",
-    name: "Open next property link",
+    name: msg.openNextPropertyLink,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -37,7 +40,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-parent-property-link",
-    name: "Open parent property link",
+    name: msg.openParentPropertyLink,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -49,7 +52,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-previous-periodic-note",
-    name: "Open previous periodic note",
+    name: msg.openPreviousPeriodicNote,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -61,7 +64,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-next-periodic-note",
-    name: "Open next periodic note",
+    name: msg.openNextPeriodicNote,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -73,7 +76,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-parent-periodic-note",
-    name: "Open parent periodic note",
+    name: msg.openParentPeriodicNote,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -85,7 +88,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-previous-folder-link",
-    name: "Open previous folder link",
+    name: msg.openPreviousFolderLink,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -97,7 +100,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-next-folder-link",
-    name: "Open next folder link",
+    name: msg.openNextFolderLink,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -109,7 +112,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-parent-folder-link",
-    name: "Open parent folder link",
+    name: msg.openParentFolderLink,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -121,7 +124,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-previous-note",
-    name: "Open previous link (for any type)",
+    name: msg.openPreviousAny,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -146,7 +149,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-next-note",
-    name: "Open next link (for any type)",
+    name: msg.openNextAny,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -171,7 +174,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "open-parent-note",
-    name: "Open parent link (for any type)",
+    name: msg.openParentAny,
     checkCallback: (checking: boolean) => {
       const file = plugin.app.workspace.getActiveFile();
       if (!file) {
@@ -196,7 +199,7 @@ export function addCommands(plugin: NavLinkHeader): void {
 
   plugin.addCommand({
     id: "toggle-match-navigation-width",
-    name: 'Toggle "Match navigation width to line length"',
+    name: msg.toggleMatchNavigationWidth,
     checkCallback: (checking: boolean) => {
       if (!checking) {
         plugin.settingsUnderChange.matchNavigationWidthToLineLength =

--- a/src/fileCreationModal.ts
+++ b/src/fileCreationModal.ts
@@ -1,5 +1,6 @@
 import { Modal, Setting } from "obsidian";
 import type NavLinkHeader from "./main";
+import { t } from "./i18n/i18n";
 
 /**
  * Modal to confirm the creation of a new file.
@@ -19,14 +20,15 @@ export class FileCreationModal extends Modal {
 
   public onOpen(): void {
     const { contentEl } = this;
-    contentEl.createEl("h1", { text: "Create a new note" });
+    const msg = t().modal;
+    contentEl.createEl("h1", { text: msg.createNewNote });
     contentEl.createEl("p", {
-      text: `File "${this.fileTitle}" does not exist. Are you sure you want to create a new note?`,
+      text: msg.fileNotExist(this.fileTitle),
     });
     new Setting(contentEl)
       .addButton((button) => {
         button
-          .setButtonText("Create")
+          .setButtonText(msg.create)
           .setCta()
           .onClick(() => {
             this.close();
@@ -34,7 +36,7 @@ export class FileCreationModal extends Modal {
           });
       })
       .addButton((button) => {
-        button.setButtonText("Create (Don't ask again)").onClick(() => {
+        button.setButtonText(msg.createDontAskAgain).onClick(() => {
           this.plugin.settingsUnderChange.confirmFileCreation = false;
           this.plugin.triggerSettingsChangedDebounced();
           this.close();
@@ -42,7 +44,7 @@ export class FileCreationModal extends Modal {
         });
       })
       .addButton((button) => {
-        button.setButtonText("Cancel").onClick(() => {
+        button.setButtonText(msg.cancel).onClick(() => {
           this.close();
         });
       });

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,0 +1,26 @@
+import type { BaseMessage } from "./types";
+import en from "./locales/en";
+import zhCN from "./locales/zh-CN";
+
+const locales: Record<string, BaseMessage> = {
+  en,
+  zh: zhCN,
+  "zh-CN": zhCN,
+};
+
+function getCurrentLanguage(): string {
+  const obsidianModule = require("obsidian") as Record<string, unknown>;
+  if (typeof obsidianModule.getLanguage === "function") {
+    return obsidianModule.getLanguage() as string;
+  }
+
+  const { moment } = window as unknown as { moment?: { locale: () => string } };
+  return moment?.locale() ?? "en";
+}
+
+const lang = getCurrentLanguage();
+const messages: BaseMessage = locales[lang] ?? locales["en"];
+
+export function t(): BaseMessage {
+  return messages;
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2,6 +2,20 @@ import type { BaseMessage } from "../types";
 
 const en: BaseMessage = {
   setting: {
+    tabs: {
+      common: "Common",
+      enabledViews: "Displayed views",
+      annotatedLinks: "Annotated links",
+      propertyLinks: "Property links",
+      periodicNotes: "Periodic notes",
+      pinnedContent: "Pinned content",
+      folderLinks: "Folder links",
+    },
+    sections: {
+      display: "Display",
+      displayPosition: "Display positions",
+      enabledViews: "Displayed views",
+    },
     threeWayDelimiterOptions: {
       full: "Full",
       "full-double-separator": "Full (double separator)",
@@ -10,6 +24,11 @@ const en: BaseMessage = {
       none: "None",
     },
     general: {
+      pluginGuide: {
+        name: "How to use",
+        desc: "First, choose target views in \"Displayed views\". Then configure data sources in the feature tabs (Annotated links / Property links / Periodic notes / Folder links). Once configured, open a note view to see the navigation header in action.",
+        linkLabel: "View official docs and examples",
+      },
       matchNavigationWidthToLineLength: {
         name: "Match navigation header width to line length",
         desc: `If enabled, the width of the navigation header will match the line length of the note.
@@ -18,12 +37,10 @@ option is enabled.`,
       },
       displayOrderOfLinks: {
         name: "Display order of links",
-        desc: `Specify the display order of links using prefix strings (e.g., emojis).
-For example:
-{periodic}, {property}, {folder}, 🏠, ⬆️, 📌, 🔗.
-Links are sorted according to the order of the prefix strings listed here.
-"{periodic}", "{property}", and "{folder}" are special strings that represent periodic
-note links, previous/next/parent property links, and folder links, respectively.`,
+        desc: `Specify the display order of links using prefix strings (e.g., emojis). For example: {periodic}, {property}, {folder}, 🏠, ⬆️, 📌, 🔗. Links are sorted according to the order of the prefix strings listed here.`,
+        descTooltip:
+          '"{periodic}", "{property}", and "{folder}" are special placeholders that represent periodic note links, previous/next/parent property links, and folder links, respectively.',
+        tip: "Separate multiple prefixes with commas.",
       },
       propertyNameForDisplayText: {
         name: "Property name to specify display text",
@@ -47,13 +64,15 @@ links with "🏠" will be displayed with the highest priority.`,
         desc: `Items whose prefix (e.g., an emoji) matches any of these strings will be collapsed
 into a single entry.
 Prefixes can also be added or removed by clicking them in the navigation header.`,
+        tip: "Separate multiple prefixes with commas.",
       },
       mergePrefixes: {
         name: "Merge prefixes",
         desc: `Specify the prefixes to merge. For example, setting 🔗 will merge links like
 🔗[[Note 1]] 🔗[[Note 2]] 🔗[[Note 3]] into 🔗[[Note 1]] [[Note 2]] [[Note 3]]
 in the navigation header.
-Multiple prefixes can be specified by separating them with commas.`,
+`,
+        tip: "Separate multiple prefixes with commas.",
       },
       displayLoadingMessage: {
         name: "Display loading message",
@@ -73,8 +92,8 @@ This option is currently only used for periodic notes.`,
         name: "Trim whitespace in input fields",
         desc: `When enabled, leading and trailing whitespace will be trimmed from the strings
 entered in the settings below.
-Disable this option if you want to include spaces intentionally.
-Affected settings: {affectedSettings}.`,
+Disable this option if you want to include spaces intentionally.`,
+        descTooltip: `Affected settings: {affectedSettings}.`,
         affectedSettings: [
           "Display order of links",
           "Duplicate link filtering priority",
@@ -98,18 +117,18 @@ Affected settings: {affectedSettings}.`,
       },
     },
     displayTargets: {
-      heading: "Display targets",
+      heading: "Displayed views",
       inPanes: {
         name: "Display navigation header in panes",
         desc: `Show navigation header when notes are opened in panes.
-This setting applies to note containers (panes). To show the navigation header,
-also enable view-specific options below.`,
+This setting applies to note containers (panes).`,
+        tip: "To show the navigation header, also enable view-specific options below.",
       },
       inPagePreviews: {
         name: "Display navigation header in page previews",
         desc: `Show navigation header when notes are shown in page previews.
-This setting applies to note containers (page previews).
-To show the navigation header, also enable view-specific options below.`,
+This setting applies to note containers (page previews).`,
+        tip: "To show the navigation header, also enable view-specific options below.",
       },
       inMarkdownViews: {
         name: "Display navigation header in Markdown views",
@@ -155,13 +174,13 @@ a link in a note content, the link is recognized as an annotated link.
 Notes with annotated links appear as backlinks in the navigation header of the
 destination note. Any string, including emoji, is acceptable as long as the following
 link is recognized as a link (Wikilink or Markdown link).
-To specify multiple annotations, separate them with commas. e.g., 📌,🔗.
-{emojiPlaceholder} can be used as a special placeholder
+Leave this field blank if you are not using this feature.`,
+        tip: "To specify multiple annotations, separate them with commas. e.g., 📌,🔗.",
+      },
+      annotationStringsForBacklinksTooltip: `{emojiPlaceholder} can be used as a special placeholder
 that represents any single emoji. For example, if you specify only
 {emojiPlaceholder}, all links preceded by an emoji will be matched.
-It can also be mixed with other entries, e.g., {emojiPlaceholder}📌,🔗.
-Leave this field blank if you are not using this feature.`,
-      },
+It can also be mixed with other entries, e.g., {emojiPlaceholder}📌,🔗。`,
       annotationStringsForCurrentNote: {
         name: "Annotation strings for current note",
         desc: `Define the annotation strings for links in the current note.
@@ -185,8 +204,8 @@ An empty string is also acceptable as a prefix.`,
       },
       advancedAnnotationStringsForCurrentNote: {
         name: "Advanced annotation strings for current note",
-        desc: `An advanced version of "Annotation strings for current note".
-The syntax is the same as that of "Advanced annotation strings for backlinks".`,
+        desc: `An advanced version of "Annotation strings for current note".`,
+        tip: 'The syntax is the same as that of "Advanced annotation strings for backlinks".',
       },
       allowSpaceAfterAnnotationString: {
         name: "Allow a space between the annotation string and the link",
@@ -209,8 +228,8 @@ that note will be displayed in the navigation header
 Each mapping consists of a property name and a string that will
 be placed at the beginning of the link when it appears in the navigation header
 (use emojis in this string if you want it to appear like an icon).
-Each line should be in the format property_name:prefix.
-To include a colon in the prefix, escape it as \\:. 
+Each line should be in the format property_name:prefix.`,
+        tip: `To include a colon in the prefix, escape it as \\:. 
 An empty string is also acceptable as a prefix.
 Leave this field blank if you are not using this feature.`,
         placeholder: "up:⬆️\nhome:🏠",
@@ -218,22 +237,22 @@ Leave this field blank if you are not using this feature.`,
       previousNotePropertyMappings: {
         name: "Previous note property mappings",
         desc: `Enter the mapping that specifies the previous note. The note specified here will
-appear in the navigation header as < previous | parent | next >.
-The syntax is the same as "Property mappings".`,
+appear in the navigation header as < previous | parent | next >.`,
+        tip: 'The syntax is the same as "Property mappings".',
         placeholder: "previous:",
       },
       nextNotePropertyMappings: {
         name: "Next note property mappings",
         desc: `Enter the mapping that specifies the next note. The note specified here will appear
-in the navigation header as < previous | parent | next >.
-The syntax is the same as "Property mappings".`,
+in the navigation header as < previous | parent | next >.`,
+        tip: 'The syntax is the same as "Property mappings".',
         placeholder: "next:",
       },
       parentNotePropertyMappings: {
         name: "Parent note property mappings",
         desc: `Enter the mapping that specifies the parent note. The note specified here will appear
-in the navigation header as < previous | parent | next >.
-The syntax is the same as "Property mappings".`,
+in the navigation header as < previous | parent | next >.`,
+        tip: 'The syntax is the same as "Property mappings".',
         placeholder: "parent:\nup:",
       },
       linkDisplayStyle: {
@@ -257,6 +276,13 @@ Enter one pair per line.`,
     },
     periodicNotes: {
       heading: "Periodic note links",
+      sections: {
+        daily: "Daily notes",
+        weekly: "Weekly notes",
+        monthly: "Monthly notes",
+        quarterly: "Quarterly notes",
+        yearly: "Yearly notes",
+      },
       displayPrevNextInDailyNotes: {
         name: "Display previous and next links in daily notes",
         desc: `To use this option, daily notes must be enabled
@@ -313,8 +339,8 @@ continues up to the end of the line.
 If the start and end markers defined below appear immediately after
 the annotation string, only the content between those markers is displayed instead.
 Example: 📌[[note 1]]/[[note 2]](end of line) → 📌[[note 1]]/[[note 2]],
-📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]].
-To specify multiple annotations, separate them with commas.`,
+📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]].`,
+        tip: "To specify multiple annotations, separate them with commas.",
         placeholder: "📌,🔗",
       },
       startMarker: { name: "Start marker", placeholder: "(" },
@@ -419,6 +445,10 @@ None: previous parent next.`,
         desc: "The string to display before each link (e.g., an emoji).",
       },
       controls: {
+        rename: "Rename",
+        expand: "Expand",
+        collapse: "Collapse",
+        pinToTop: "Pin to top",
         moveUp: "Move up",
         moveDown: "Move down",
         remove: "Remove",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,460 @@
+import type { BaseMessage } from "../types";
+
+const en: BaseMessage = {
+  setting: {
+    threeWayDelimiterOptions: {
+      full: "Full",
+      "full-double-separator": "Full (double separator)",
+      separator: "Separator",
+      "double-separator": "Double separator",
+      none: "None",
+    },
+    general: {
+      matchNavigationWidthToLineLength: {
+        name: "Match navigation header width to line length",
+        desc: `If enabled, the width of the navigation header will match the line length of the note.
+Here, "line length" refers to the width defined when Obsidian's "Readable line length"
+option is enabled.`,
+      },
+      displayOrderOfLinks: {
+        name: "Display order of links",
+        desc: `Specify the display order of links using prefix strings (e.g., emojis).
+For example:
+{periodic}, {property}, {folder}, 🏠, ⬆️, 📌, 🔗.
+Links are sorted according to the order of the prefix strings listed here.
+"{periodic}", "{property}", and "{folder}" are special strings that represent periodic
+note links, previous/next/parent property links, and folder links, respectively.`,
+      },
+      propertyNameForDisplayText: {
+        name: "Property name to specify display text",
+        desc: `If you want to use file properties to specify the note's display text, set the
+property name to this field. Leave this field blank if you are not using this feature.`,
+        placeholder: "title",
+      },
+      filterDuplicateLinks: {
+        name: "Filter duplicate links",
+        desc: `Filter out duplicates when multiple links with the same destination are detected.
+This setting does not apply to prev/next/parent-type links and pinned note contents.`,
+      },
+      duplicateLinkFilteringPriority: {
+        name: "Duplicate link filtering priority",
+        desc: `Specify the filtering priority.
+For example, if you specify 🏠,⬆️,📌,🔗 here,
+links with "🏠" will be displayed with the highest priority.`,
+      },
+      itemCollapsePrefixes: {
+        name: "Item collapse prefixes",
+        desc: `Items whose prefix (e.g., an emoji) matches any of these strings will be collapsed
+into a single entry.
+Prefixes can also be added or removed by clicking them in the navigation header.`,
+      },
+      mergePrefixes: {
+        name: "Merge prefixes",
+        desc: `Specify the prefixes to merge. For example, setting 🔗 will merge links like
+🔗[[Note 1]] 🔗[[Note 2]] 🔗[[Note 3]] into 🔗[[Note 1]] [[Note 2]] [[Note 3]]
+in the navigation header.
+Multiple prefixes can be specified by separating them with commas.`,
+      },
+      displayLoadingMessage: {
+        name: "Display loading message",
+        desc: `Display a loading message ("Loading...") in the navigation header
+while links are being loaded.`,
+      },
+      displayPlaceholder: {
+        name: "Display placeholder",
+        desc: `Display a placeholder ("No links") when there is nothing to display.`,
+      },
+      confirmFileCreation: {
+        name: "Confirm when creating a new file",
+        desc: `Display a confirmation dialog when a new file is created.
+This option is currently only used for periodic notes.`,
+      },
+      trimWhitespaceInInputFields: {
+        name: "Trim whitespace in input fields",
+        desc: `When enabled, leading and trailing whitespace will be trimmed from the strings
+entered in the settings below.
+Disable this option if you want to include spaces intentionally.
+Affected settings: {affectedSettings}.`,
+        affectedSettings: [
+          "Display order of links",
+          "Duplicate link filtering priority",
+          "Item collapse prefixes",
+          "Merge prefixes",
+          "Annotation strings for backlinks",
+          "Annotation strings for current note",
+          "Advanced annotation strings for backlinks",
+          "Advanced annotation strings for current note",
+          "Previous note property mappings",
+          "Next note property mappings",
+          "Parent note property mappings",
+          "Link prefix (Periodic note links)",
+          "Annotation strings (Pinned note content)",
+          "Start marker",
+          "End marker",
+          "Include patterns",
+          "Exclude patterns",
+          "Link prefix (Folder links)",
+        ],
+      },
+    },
+    displayTargets: {
+      heading: "Display targets",
+      inPanes: {
+        name: "Display navigation header in panes",
+        desc: `Show navigation header when notes are opened in panes.
+This setting applies to note containers (panes). To show the navigation header,
+also enable view-specific options below.`,
+      },
+      inPagePreviews: {
+        name: "Display navigation header in page previews",
+        desc: `Show navigation header when notes are shown in page previews.
+This setting applies to note containers (page previews).
+To show the navigation header, also enable view-specific options below.`,
+      },
+      inMarkdownViews: {
+        name: "Display navigation header in Markdown views",
+        desc: "Show navigation header when viewing Markdown documents.",
+      },
+      inImageViews: {
+        name: "Display navigation header in Image views",
+        desc: "Show navigation header when viewing images.",
+      },
+      inVideoViews: {
+        name: "Display navigation header in Video views",
+        desc: "Show navigation header when viewing videos.",
+      },
+      inAudioViews: {
+        name: "Display navigation header in Audio views",
+        desc: "Show navigation header when viewing audio.",
+      },
+      inPdfViews: {
+        name: "Display navigation header in PDF views",
+        desc: "Show navigation header when viewing PDFs.",
+      },
+      inCanvasViews: {
+        name: "Display navigation header in Canvas views",
+        desc: "Show navigation header when viewing Canvas.",
+      },
+      inBasesViews: {
+        name: "Display navigation header in Bases views",
+        desc: "Show navigation header when viewing Bases.",
+      },
+      inOtherViews: {
+        name: "Display navigation header in other views",
+        desc: `Show navigation header in other views (such as views introduced by community plugins).
+This may not work depending on the view type.`,
+      },
+    },
+    annotatedLinks: {
+      heading: "Annotated links",
+      annotationStringsForBacklinks: {
+        name: "Annotation strings for backlinks",
+        desc: `Define the annotation strings.
+If one of the annotation strings (e.g., emojis) is placed immediately before
+a link in a note content, the link is recognized as an annotated link.
+Notes with annotated links appear as backlinks in the navigation header of the
+destination note. Any string, including emoji, is acceptable as long as the following
+link is recognized as a link (Wikilink or Markdown link).
+To specify multiple annotations, separate them with commas. e.g., 📌,🔗.
+{emojiPlaceholder} can be used as a special placeholder
+that represents any single emoji. For example, if you specify only
+{emojiPlaceholder}, all links preceded by an emoji will be matched.
+It can also be mixed with other entries, e.g., {emojiPlaceholder}📌,🔗.
+Leave this field blank if you are not using this feature.`,
+      },
+      annotationStringsForCurrentNote: {
+        name: "Annotation strings for current note",
+        desc: `Define the annotation strings for links in the current note.
+This setting works the same way as "Annotation strings for backlinks",
+but applies to links in the current note.`,
+      },
+      hidePrefixes: {
+        name: "Hide prefixes in the navigation header",
+        desc: "If enabled, prefixes (e.g., emojis) will be hidden in the navigation header.",
+      },
+      advancedAnnotationStringsForBacklinks: {
+        name: "Advanced annotation strings for backlinks",
+        desc: `An advanced version of "Annotation strings for backlinks".
+This setting allows regular expressions to be used as
+annotation strings and any prefix (e.g., an emoji) to be assigned for display
+in the navigation header.
+Enter one mapping per line using the format regex:prefix.
+To include a colon in the prefix, escape it as "\\:".
+An empty string is also acceptable as a prefix.`,
+        placeholder: "📌:🔗\n(?:^|\\n)-:\n\\[\\[E\\]\\]:🔗",
+      },
+      advancedAnnotationStringsForCurrentNote: {
+        name: "Advanced annotation strings for current note",
+        desc: `An advanced version of "Annotation strings for current note".
+The syntax is the same as that of "Advanced annotation strings for backlinks".`,
+      },
+      allowSpaceAfterAnnotationString: {
+        name: "Allow a space between the annotation string and the link",
+        desc: `If enabled, a link will still be recognized as an annotated link even if there is a
+space between the annotation string and the link.`,
+      },
+      ignoreVariationSelectors: {
+        name: "Ignore variation selectors",
+        desc: "If enabled, emoji variation selectors (VS15/VS16) are ignored when matching links.",
+      },
+    },
+    propertyLinks: {
+      heading: "Property links",
+      propertyMappings: {
+        name: "Property mappings",
+        desc: `Define the property mappings.
+If the file property specified here points to a specific note,
+that note will be displayed in the navigation header
+(URLs to the website are also supported).
+Each mapping consists of a property name and a string that will
+be placed at the beginning of the link when it appears in the navigation header
+(use emojis in this string if you want it to appear like an icon).
+Each line should be in the format property_name:prefix.
+To include a colon in the prefix, escape it as \\:. 
+An empty string is also acceptable as a prefix.
+Leave this field blank if you are not using this feature.`,
+        placeholder: "up:⬆️\nhome:🏠",
+      },
+      previousNotePropertyMappings: {
+        name: "Previous note property mappings",
+        desc: `Enter the mapping that specifies the previous note. The note specified here will
+appear in the navigation header as < previous | parent | next >.
+The syntax is the same as "Property mappings".`,
+        placeholder: "previous:",
+      },
+      nextNotePropertyMappings: {
+        name: "Next note property mappings",
+        desc: `Enter the mapping that specifies the next note. The note specified here will appear
+in the navigation header as < previous | parent | next >.
+The syntax is the same as "Property mappings".`,
+        placeholder: "next:",
+      },
+      parentNotePropertyMappings: {
+        name: "Parent note property mappings",
+        desc: `Enter the mapping that specifies the parent note. The note specified here will appear
+in the navigation header as < previous | parent | next >.
+The syntax is the same as "Property mappings".`,
+        placeholder: "parent:\nup:",
+      },
+      linkDisplayStyle: {
+        name: "Link display style",
+        desc: `Specify the display style of prev/next/parent links in the navigation header.
+Full: < previous | parent | next >,
+Full (double separator): < previous || parent || next >,
+Separator: previous | parent | next,
+Double separator: previous || parent || next,
+None: previous parent next.`,
+      },
+      implicitReciprocalPropertyPairs: {
+        name: "Implicit reciprocal property pairs",
+        desc: `Specify pairs of property names here to implicitly create reciprocal links
+in the navigation header. For example, if you enter prev:next here,
+when Note A has a property "next: [[Note B]]", Note B will be treated as if
+it also had "prev: [[Note A]]" even if it isn't explicitly set.
+Enter one pair per line.`,
+        placeholder: "prev:next\nparent:child",
+      },
+    },
+    periodicNotes: {
+      heading: "Periodic note links",
+      displayPrevNextInDailyNotes: {
+        name: "Display previous and next links in daily notes",
+        desc: `To use this option, daily notes must be enabled
+in Daily Notes plugin or Periodic Notes plugin.`,
+      },
+      parentForDailyNotes: { name: "Parent for daily notes" },
+      displayPrevNextInWeeklyNotes: {
+        name: "Display previous and next links in weekly notes",
+        desc: "To use this option, weekly notes must be enabled in Periodic Notes plugin.",
+      },
+      parentForWeeklyNotes: { name: "Parent for weekly notes" },
+      displayPrevNextInMonthlyNotes: {
+        name: "Display previous and next links in monthly notes",
+        desc: "To use this option, monthly notes must be enabled in Periodic Notes plugin.",
+      },
+      parentForMonthlyNotes: { name: "Parent for monthly notes" },
+      displayPrevNextInQuarterlyNotes: {
+        name: "Display previous and next links in quarterly notes",
+        desc: "To use this option, quarterly notes must be enabled in Periodic Notes plugin.",
+      },
+      parentForQuarterlyNotes: { name: "Parent for quarterly notes" },
+      displayPrevNextInYearlyNotes: {
+        name: "Display previous and next links in yearly notes",
+        desc: "To use this option, yearly notes must be enabled in Periodic Notes plugin.",
+      },
+      linkDisplayStyle: {
+        name: "Link display style",
+        desc: `Specify the display style of links in the navigation header.
+Full: < previous | parent | next >,
+Full (double separator): < previous || parent || next >,
+Separator: previous | parent | next,
+Double separator: previous || parent || next,
+None: previous parent next.`,
+      },
+      linkPrefix: {
+        name: "Link prefix",
+        desc: "The string to display before each link (e.g., an emoji).",
+      },
+      granularityOptions: {
+        none: "None",
+        week: "Weekly",
+        month: "Monthly",
+        quarter: "Quarterly",
+        year: "Yearly",
+      },
+    },
+    pinnedContent: {
+      heading: "Pinned note content",
+      annotationStrings: {
+        name: "Annotation strings",
+        desc: `Display part of the current note in the navigation header.
+The text shown starts immediately after the specified annotation string and
+continues up to the end of the line.
+If the start and end markers defined below appear immediately after
+the annotation string, only the content between those markers is displayed instead.
+Example: 📌[[note 1]]/[[note 2]](end of line) → 📌[[note 1]]/[[note 2]],
+📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]].
+To specify multiple annotations, separate them with commas.`,
+        placeholder: "📌,🔗",
+      },
+      startMarker: { name: "Start marker", placeholder: "(" },
+      endMarker: { name: "End marker", placeholder: ")" },
+      ignoreCodeBlocks: {
+        name: "Ignore code blocks",
+        desc: "If enabled, code blocks will be ignored when searching for pinned content.",
+      },
+    },
+    folderLinks: {
+      heading: "Folder links",
+      folderSettingHeading: (index: number) => `Folder setting #${index}`,
+      folderPaths: {
+        name: "Folder paths",
+        desc: `For each folder specified here, files in the same folder as the currently opened
+file will be shown in the navigation header. Multiple folders can be specified
+(enter one path per line). Glob patterns are supported
+(e.g., **: all folders; *: all folders directly under root;
+folder/*: all folders directly under "folder").`,
+        placeholder: "path/to/the/folder\nanother/folder/*",
+      },
+      excludedFolderPaths: {
+        name: "Excluded folder paths",
+        desc: `Specify the folder paths to exclude. Multiple folders can be specified
+(enter one path per line). Glob patterns are supported.`,
+        placeholder: "path/to/the/folder\nanother/folder/*",
+      },
+      recursive: {
+        name: "Recursive",
+        desc: "Whether to include files in subfolders.",
+      },
+      includePatterns: {
+        name: "Include patterns",
+        desc: `Include files that match these patterns partially. Enter one per line.
+Leave empty for all files.`,
+        placeholder: "Chapter\n.pdf",
+      },
+      excludePatterns: {
+        name: "Exclude patterns",
+        desc: "Exclude files that match these patterns partially. Enter one per line.",
+        placeholder: ".canvas",
+      },
+      enableRegex: {
+        name: "Enable regular expressions",
+        desc: "Whether to enable regular expressions for include/exclude patterns.",
+      },
+      filterBy: {
+        name: "Filter by",
+        desc: "Specify whether to use file names or property values for include/exclude patterns.",
+        options: {
+          filename: "File name",
+          property: "Property",
+        },
+      },
+      propertyNameToFilterBy: {
+        name: "Property name to filter by",
+        desc: `The name of the property to filter by.
+This is required when "Filter by" is set to "Property".`,
+      },
+      sortOrder: {
+        name: "Sort order",
+        options: {
+          asc: "Ascending",
+          desc: "Descending",
+        },
+      },
+      sortBy: {
+        name: "Sort by",
+        options: {
+          filename: "File name",
+          created: "Creation date",
+          modified: "Modification date",
+          property: "Property",
+        },
+      },
+      propertyNameToSortBy: {
+        name: "Property name to sort by",
+        desc: `The name of the property to sort by.
+This is required when "Sort by" is set to "Property".`,
+      },
+      maxLinks: {
+        name: "Max links",
+        desc: `The maximum number of folder links to display.
+For example, if set to 3, the display would look like
+<prev3 prev2 prev1 | parent | next1 next2 next3>.`,
+      },
+      pathToParentNote: {
+        name: "Path to the parent note",
+        placeholder: "path/to/the/note.md",
+      },
+      linkDisplayStyle: {
+        name: "Link display style",
+        desc: `Specify the display style of prev/next/parent links in the navigation header.
+Full: < previous | parent | next >,
+Full (double separator): < previous || parent || next >,
+Separator: previous | parent | next,
+Double separator: previous || parent || next,
+None: previous parent next.`,
+      },
+      linkPrefix: {
+        name: "Link prefix",
+        desc: "The string to display before each link (e.g., an emoji).",
+      },
+      controls: {
+        moveUp: "Move up",
+        moveDown: "Move down",
+        remove: "Remove",
+        addFolderSetting: "Add folder setting",
+      },
+    },
+  },
+  command: {
+    openPreviousPropertyLink: "Open previous property link",
+    openNextPropertyLink: "Open next property link",
+    openParentPropertyLink: "Open parent property link",
+    openPreviousPeriodicNote: "Open previous periodic note",
+    openNextPeriodicNote: "Open next periodic note",
+    openParentPeriodicNote: "Open parent periodic note",
+    openPreviousFolderLink: "Open previous folder link",
+    openNextFolderLink: "Open next folder link",
+    openParentFolderLink: "Open parent folder link",
+    openPreviousAny: "Open previous link (for any type)",
+    openNextAny: "Open next link (for any type)",
+    openParentAny: "Open parent link (for any type)",
+    toggleMatchNavigationWidth: 'Toggle "Match navigation width to line length"',
+  },
+  modal: {
+    createNewNote: "Create a new note",
+    fileNotExist: (fileTitle: string) =>
+      `File "${fileTitle}" does not exist. Are you sure you want to create a new note?`,
+    create: "Create",
+    createDontAskAgain: "Create (Don't ask again)",
+    cancel: "Cancel",
+  },
+  ui: {
+    loading: "Loading...",
+    noLinks: "No links",
+    collapsedCount: (itemCount: number) =>
+      `(${itemCount} ${itemCount === 1 ? "item" : "items"})`,
+  },
+};
+
+export default en;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -4,7 +4,7 @@ const en: BaseMessage = {
   setting: {
     tabs: {
       common: "Common",
-      enabledViews: "Displayed views",
+      enabledViews: "Views",
       annotatedLinks: "Annotated links",
       propertyLinks: "Property links",
       periodicNotes: "Periodic notes",
@@ -13,7 +13,6 @@ const en: BaseMessage = {
     },
     sections: {
       display: "Display",
-      displayPosition: "Display positions",
       enabledViews: "Displayed views",
     },
     threeWayDelimiterOptions: {
@@ -352,6 +351,11 @@ Example: 📌[[note 1]]/[[note 2]](end of line) → 📌[[note 1]]/[[note 2]],
     },
     folderLinks: {
       heading: "Folder links",
+      intro: {
+        desc: `Create folder link rules to display links to files in specific folders.
+You can add multiple rules, each with its own configuration.`,
+        tip: `Click on the Folder Setting title to rename it.`,
+      },
       folderSettingHeading: (index: number) => `Folder setting #${index}`,
       folderPaths: {
         name: "Folder paths",
@@ -477,6 +481,7 @@ None: previous parent next.`,
       `File "${fileTitle}" does not exist. Are you sure you want to create a new note?`,
     create: "Create",
     createDontAskAgain: "Create (Don't ask again)",
+    save: "Save",
     cancel: "Cancel",
   },
   ui: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1,0 +1,446 @@
+import type { BaseMessage } from "../types";
+
+const zhCN: BaseMessage = {
+  setting: {
+    threeWayDelimiterOptions: {
+      full: "完整",
+      "full-double-separator": "完整（双分隔符）",
+      separator: "分隔符",
+      "double-separator": "双分隔符",
+      none: "无",
+    },
+    general: {
+      matchNavigationWidthToLineLength: {
+        name: "让导航栏宽度匹配行宽",
+        desc: `启用后，导航栏的宽度会与笔记内容的行宽一致。
+这里的「行宽」指的是 Obsidian 启用「Readable line length」时定义的宽度。`,
+      },
+      displayOrderOfLinks: {
+        name: "链接显示顺序",
+        desc: `使用前缀字符串（例如 emoji）指定链接显示顺序。
+例如：
+{periodic}、{property}、{folder}、🏠、⬆️、📌、🔗。
+链接会按这里列出的前缀顺序排序。
+"{periodic}"、"{property}" 和 "{folder}" 是特殊字符串，分别代表
+周期笔记链接、上一条/下一条/父级属性链接，以及文件夹链接。`,
+      },
+      propertyNameForDisplayText: {
+        name: "作为显示名称的属性名",
+        desc: `如果你想用文件属性作为笔记显示文本，请在此填写属性名。
+不使用该功能时请留空。`,
+        placeholder: "title",
+      },
+      filterDuplicateLinks: {
+        name: "过滤重复链接",
+        desc: `当检测到多个目标相同的链接时，自动过滤重复项。
+此设置不适用于上一条/下一条/父级类型链接和置顶笔记内容。`,
+      },
+      duplicateLinkFilteringPriority: {
+        name: "重复链接过滤优先级",
+        desc: `指定过滤优先级。
+例如这里填写 🏠,⬆️,📌,🔗 时，带有「🏠」的链接优先级最高。`,
+      },
+      itemCollapsePrefixes: {
+        name: "折叠前缀",
+        desc: `带有下列前缀（例如 emoji）的项目会自动折叠。
+你也可以在导航栏中点击前缀来折叠/取消折叠。`,
+      },
+      mergePrefixes: {
+        name: "合并前缀",
+        desc: `指定要合并的前缀。例如设置 🔗 后，导航栏中的
+🔗[[Note 1]] 🔗[[Note 2]] 🔗[[Note 3]] 会合并为 🔗[[Note 1]] [[Note 2]] [[Note 3]]。
+多个前缀请使用英文逗号分隔。`,
+      },
+      displayLoadingMessage: {
+        name: "显示加载提示",
+        desc: `链接加载过程中，在导航栏显示加载提示（「Loading...」）。`,
+      },
+      displayPlaceholder: {
+        name: "显示占位提示",
+        desc: `当没有可显示内容时，显示占位提示（「No links」）。`,
+      },
+      confirmFileCreation: {
+        name: "创建新文件时确认",
+        desc: `创建新文件时显示确认对话框。
+该选项当前仅用于周期笔记。`,
+      },
+      trimWhitespaceInInputFields: {
+        name: "裁剪输入字段首尾空白",
+        desc: `启用后，会自动去除下方设置中输入字符串的首尾空白。
+如果你需要保留空格，请关闭此选项。
+受影响设置：{affectedSettings}。`,
+        affectedSettings: [
+          "链接显示顺序",
+          "重复链接过滤优先级",
+          "折叠前缀",
+          "合并前缀",
+          "反向链接注释字符串",
+          "当前笔记注释字符串",
+          "反向链接高级注释字符串",
+          "当前笔记高级注释字符串",
+          "上一条笔记属性映射",
+          "下一条笔记属性映射",
+          "父级笔记属性映射",
+          "链接前缀（周期笔记链接）",
+          "注释字符串（置顶笔记内容）",
+          "起始标记",
+          "结束标记",
+          "包含模式",
+          "排除模式",
+          "链接前缀（文件夹链接）",
+        ],
+      },
+    },
+    displayTargets: {
+      heading: "显示位置",
+      inPanes: {
+        name: "窗格",
+        desc: `在笔记以窗格形式打开时显示导航栏。
+该设置作用于笔记容器（窗格）。要真正显示导航栏，
+还需要启用下方对应视图类型的选项。`,
+      },
+      inPagePreviews: {
+        name: "页面预览",
+        desc: `在页面预览中显示笔记时显示导航栏。
+该设置作用于笔记容器（页面预览）。
+要真正显示导航栏，还需要启用下方对应视图类型的选项。`,
+      },
+      inMarkdownViews: {
+        name: "Markdown 视图",
+        desc: "查看 Markdown 文档时显示导航栏。",
+      },
+      inImageViews: {
+        name: "图片视图",
+        desc: "查看图片时显示导航栏。",
+      },
+      inVideoViews: {
+        name: "视频视图",
+        desc: "查看视频时显示导航栏。",
+      },
+      inAudioViews: {
+        name: "音频视图",
+        desc: "查看音频时显示导航栏。",
+      },
+      inPdfViews: {
+        name: "PDF 视图",
+        desc: "查看 PDF 时显示导航栏。",
+      },
+      inCanvasViews: {
+        name: "Canvas 视图",
+        desc: "查看 Canvas 时显示导航栏。",
+      },
+      inBasesViews: {
+        name: "Bases 视图",
+        desc: "查看 Bases 时显示导航栏。",
+      },
+      inOtherViews: {
+        name: "其他视图",
+        desc: `在其他视图（如社区插件引入的视图）中显示导航栏。
+是否生效取决于具体视图类型。`,
+      },
+    },
+    annotatedLinks: {
+      heading: "注释链接",
+      annotationStringsForBacklinks: {
+        name: "反向链接注释字符串",
+        desc: `定义注释字符串。
+如果在笔记内容中，链接前紧邻某个注释字符串（例如 emoji），
+该链接会被识别为注释链接。
+包含注释链接的笔记会显示在目标笔记导航栏的反向链接中。
+只要后续内容可被识别为链接（Wikilink 或 Markdown 链接），
+任意字符串（包括 emoji）都可以作为注释字符串。
+多个注释请用英文逗号分隔，例如 📌,🔗。
+{emojiPlaceholder} 可作为特殊占位符，表示任意单个 emoji。
+例如仅填写 {emojiPlaceholder} 时，所有前面带 emoji 的链接都会匹配。
+它也可以与其他条目混用，例如 {emojiPlaceholder}📌,🔗。
+如果不使用此功能，请留空。`,
+      },
+      annotationStringsForCurrentNote: {
+        name: "当前笔记注释字符串",
+        desc: `定义当前笔记中链接使用的注释字符串。
+该设置与「反向链接注释字符串」相同，但作用于当前笔记内的链接。`,
+      },
+      hidePrefixes: {
+        name: "在导航栏中隐藏前缀",
+        desc: "启用后，导航栏中的前缀（例如 emoji）将被隐藏。",
+      },
+      advancedAnnotationStringsForBacklinks: {
+        name: "反向链接高级注释字符串",
+        desc: `「反向链接注释字符串」的高级版本。
+该设置允许用正则表达式作为注释字符串，并指定任意前缀（例如 emoji）
+用于导航栏显示。
+每行输入一条映射，格式为 regex:prefix。
+若前缀中需要冒号，请使用 "\\:" 转义。
+前缀也可以为空字符串。`,
+        placeholder: "📌:🔗\n(?:^|\\n)-:\n\\[\\[E\\]\\]:🔗",
+      },
+      advancedAnnotationStringsForCurrentNote: {
+        name: "当前笔记高级注释字符串",
+        desc: `「当前笔记注释字符串」的高级版本。
+语法与「反向链接高级注释字符串」一致。`,
+      },
+      allowSpaceAfterAnnotationString: {
+        name: "允许注释字符串与链接之间有空格",
+        desc: `启用后，即使注释字符串与链接之间有空格，链接仍会被识别为注释链接。`,
+      },
+      ignoreVariationSelectors: {
+        name: "忽略变体选择符",
+        desc: "启用后，匹配链接时会忽略 emoji 变体选择符（VS15/VS16）。",
+      },
+    },
+    propertyLinks: {
+      heading: "属性链接",
+      propertyMappings: {
+        name: "属性映射",
+        desc: `定义属性映射。
+如果这里指定的文件属性指向某个笔记，
+该笔记会显示在导航栏中（也支持网站 URL）。
+每条映射由属性名和一个前缀字符串组成，
+当前缀链接出现在导航栏时会显示该字符串
+（如果想作为图标显示，可使用 emoji）。
+每行格式为 property_name:prefix。
+若前缀中需要冒号，请使用 \\: 转义。
+前缀也可以为空字符串。
+如果不使用此功能，请留空。`,
+        placeholder: "up:⬆️\nhome:🏠",
+      },
+      previousNotePropertyMappings: {
+        name: "上一条笔记属性映射",
+        desc: `输入用于指定上一条笔记的映射。这里指定的笔记会在导航栏中显示为
+< previous | parent | next >。
+语法与「属性映射」相同。`,
+        placeholder: "previous:",
+      },
+      nextNotePropertyMappings: {
+        name: "下一条笔记属性映射",
+        desc: `输入用于指定下一条笔记的映射。这里指定的笔记会在导航栏中显示为
+< previous | parent | next >。
+语法与「属性映射」相同。`,
+        placeholder: "next:",
+      },
+      parentNotePropertyMappings: {
+        name: "父级笔记属性映射",
+        desc: `输入用于指定父级笔记的映射。这里指定的笔记会在导航栏中显示为
+< previous | parent | next >。
+语法与「属性映射」相同。`,
+        placeholder: "parent:\nup:",
+      },
+      linkDisplayStyle: {
+        name: "链接显示样式",
+        desc: `指定导航栏中上一条/下一条/父级链接的显示样式。
+完整：< previous | parent | next >，
+完整（双分隔符）：< previous || parent || next >，
+分隔符：previous | parent | next，
+双分隔符：previous || parent || next，
+无：previous parent next。`,
+      },
+      implicitReciprocalPropertyPairs: {
+        name: "隐式互反属性对",
+        desc: `在这里指定属性名对，可在导航栏中隐式创建互反链接。
+例如输入 prev:next 后，当笔记 A 有属性 "next: [[笔记 B]]" 时，
+即使未显式设置，笔记 B 也会被视为拥有 "prev: [[笔记 A]]"。
+每行输入一对。`,
+        placeholder: "prev:next\nparent:child",
+      },
+    },
+    periodicNotes: {
+      heading: "周期笔记链接",
+      displayPrevNextInDailyNotes: {
+        name: "在日记中显示上一条和下一条链接",
+        desc: `使用此选项前，请先在 Daily Notes 插件或 Periodic Notes 插件中启用日记。`,
+      },
+      parentForDailyNotes: { name: "日记的父级" },
+      displayPrevNextInWeeklyNotes: {
+        name: "在周记中显示上一条和下一条链接",
+        desc: "使用此选项前，请先在 Periodic Notes 插件中启用周记。",
+      },
+      parentForWeeklyNotes: { name: "周记的父级" },
+      displayPrevNextInMonthlyNotes: {
+        name: "在月记中显示上一条和下一条链接",
+        desc: "使用此选项前，请先在 Periodic Notes 插件中启用月记。",
+      },
+      parentForMonthlyNotes: { name: "月记的父级" },
+      displayPrevNextInQuarterlyNotes: {
+        name: "在季记中显示上一条和下一条链接",
+        desc: "使用此选项前，请先在 Periodic Notes 插件中启用季记。",
+      },
+      parentForQuarterlyNotes: { name: "季记的父级" },
+      displayPrevNextInYearlyNotes: {
+        name: "在年记中显示上一条和下一条链接",
+        desc: "使用此选项前，请先在 Periodic Notes 插件中启用年记。",
+      },
+      linkDisplayStyle: {
+        name: "链接显示样式",
+        desc: `指定导航栏中链接的显示样式。
+完整：< previous | parent | next >，
+完整（双分隔符）：< previous || parent || next >，
+分隔符：previous | parent | next，
+双分隔符：previous || parent || next，
+无：previous parent next。`,
+      },
+      linkPrefix: {
+        name: "链接前缀",
+        desc: "显示在每个链接前的字符串（例如 emoji）。",
+      },
+      granularityOptions: {
+        none: "无",
+        week: "周记",
+        month: "月记",
+        quarter: "季记",
+        year: "年记",
+      },
+    },
+    pinnedContent: {
+      heading: "置顶笔记内容",
+      annotationStrings: {
+        name: "注释字符串",
+        desc: `在导航栏中显示当前笔记的一部分内容。
+显示文本会从指定注释字符串后立即开始，
+一直持续到该行末尾。
+如果注释字符串后紧跟下方定义的起始和结束标记，
+则只显示这两个标记之间的内容。
+示例：📌[[note 1]]/[[note 2]](行末) → 📌[[note 1]]/[[note 2]]，
+📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]]。
+多个注释请用英文逗号分隔。`,
+        placeholder: "📌,🔗",
+      },
+      startMarker: { name: "起始标记", placeholder: "(" },
+      endMarker: { name: "结束标记", placeholder: ")" },
+      ignoreCodeBlocks: {
+        name: "忽略代码块",
+        desc: "启用后，搜索置顶内容时会忽略代码块。",
+      },
+    },
+    folderLinks: {
+      heading: "文件夹链接",
+      folderSettingHeading: (index: number) => `文件夹设置 #${index}`,
+      folderPaths: {
+        name: "文件夹路径",
+        desc: `对这里指定的每个文件夹，若当前打开文件位于该文件夹中，
+同文件夹中的文件会显示在导航栏里。可指定多个文件夹
+（每行一个路径）。支持 Glob 模式
+（例如 **：所有文件夹；*：根目录下一级所有文件夹；
+folder/*：folder 下一级所有文件夹）。`,
+        placeholder: "path/to/the/folder\nanother/folder/*",
+      },
+      excludedFolderPaths: {
+        name: "排除的文件夹路径",
+        desc: `指定要排除的文件夹路径。可指定多个文件夹
+（每行一个路径）。支持 Glob 模式。`,
+        placeholder: "path/to/the/folder\nanother/folder/*",
+      },
+      recursive: {
+        name: "递归",
+        desc: "是否包含子文件夹中的文件。",
+      },
+      includePatterns: {
+        name: "包含模式",
+        desc: `部分匹配这些模式的文件会被包含。每行一个。
+留空则包含所有文件。`,
+        placeholder: "Chapter\n.pdf",
+      },
+      excludePatterns: {
+        name: "排除模式",
+        desc: "部分匹配这些模式的文件会被排除。每行一个。",
+        placeholder: ".canvas",
+      },
+      enableRegex: {
+        name: "启用正则表达式",
+        desc: "是否在包含/排除模式中启用正则表达式。",
+      },
+      filterBy: {
+        name: "筛选依据",
+        desc: "指定包含/排除模式基于文件名还是属性值。",
+        options: {
+          filename: "文件名",
+          property: "属性",
+        },
+      },
+      propertyNameToFilterBy: {
+        name: "用于筛选的属性名",
+        desc: `用于筛选的属性名。
+当「筛选依据」设为「属性」时，此项必填。`,
+      },
+      sortOrder: {
+        name: "排序顺序",
+        options: {
+          asc: "升序",
+          desc: "降序",
+        },
+      },
+      sortBy: {
+        name: "排序依据",
+        options: {
+          filename: "文件名",
+          created: "创建时间",
+          modified: "修改时间",
+          property: "属性",
+        },
+      },
+      propertyNameToSortBy: {
+        name: "用于排序的属性名",
+        desc: `用于排序的属性名。
+当「排序依据」设为「属性」时，此项必填。`,
+      },
+      maxLinks: {
+        name: "最大链接数",
+        desc: `显示的文件夹链接最大数量。
+例如设为 3 时，显示形态类似
+<prev3 prev2 prev1 | parent | next1 next2 next3>。`,
+      },
+      pathToParentNote: {
+        name: "父级笔记路径",
+        placeholder: "path/to/the/note.md",
+      },
+      linkDisplayStyle: {
+        name: "链接显示样式",
+        desc: `指定导航栏中上一条/下一条/父级链接的显示样式。
+完整：< previous | parent | next >，
+完整（双分隔符）：< previous || parent || next >，
+分隔符：previous | parent | next，
+双分隔符：previous || parent || next，
+无：previous parent next。`,
+      },
+      linkPrefix: {
+        name: "链接前缀",
+        desc: "显示在每个链接前的字符串（例如 emoji）。",
+      },
+      controls: {
+        moveUp: "上移",
+        moveDown: "下移",
+        remove: "移除",
+        addFolderSetting: "添加文件夹设置",
+      },
+    },
+  },
+  command: {
+    openPreviousPropertyLink: "打开上一条属性链接",
+    openNextPropertyLink: "打开下一条属性链接",
+    openParentPropertyLink: "打开父级属性链接",
+    openPreviousPeriodicNote: "打开上一条周期笔记",
+    openNextPeriodicNote: "打开下一条周期笔记",
+    openParentPeriodicNote: "打开父级周期笔记",
+    openPreviousFolderLink: "打开上一条文件夹链接",
+    openNextFolderLink: "打开下一条文件夹链接",
+    openParentFolderLink: "打开父级文件夹链接",
+    openPreviousAny: "打开上一条链接（任意类型）",
+    openNextAny: "打开下一条链接（任意类型）",
+    openParentAny: "打开父级链接（任意类型）",
+    toggleMatchNavigationWidth: "切换「让导航栏宽度匹配行宽」",
+  },
+  modal: {
+    createNewNote: "创建新笔记",
+    fileNotExist: (fileTitle: string) =>
+      `文件「${fileTitle}」不存在。确定要创建新笔记吗？`,
+    create: "创建",
+    createDontAskAgain: "创建（不再询问）",
+    cancel: "取消",
+  },
+  ui: {
+    loading: "加载中...",
+    noLinks: "无链接",
+    collapsedCount: (itemCount: number) => `（${itemCount} 项）`,
+  },
+};
+
+export default zhCN;

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2,6 +2,20 @@ import type { BaseMessage } from "../types";
 
 const zhCN: BaseMessage = {
   setting: {
+    tabs: {
+      common: "通用",
+      enabledViews: "显示视图",
+      annotatedLinks: "注释链接",
+      propertyLinks: "属性链接",
+      periodicNotes: "周期笔记",
+      pinnedContent: "置顶注释",
+      folderLinks: "文件夹链接",
+    },
+    sections: {
+      display: "显示",
+      displayPosition: "显示位置",
+      enabledViews: "显示视图",
+    },
     threeWayDelimiterOptions: {
       full: "完整",
       "full-double-separator": "完整（双分隔符）",
@@ -10,6 +24,11 @@ const zhCN: BaseMessage = {
       none: "无",
     },
     general: {
+      pluginGuide: {
+        name: "插件使用说明",
+        desc: "先在「显示视图」中选择需要显示导航栏的视图，再到各功能标签页（注释链接 / 属性链接 / 周期笔记 / 文件夹链接）配置链接的数据来源。配置完成后，返回笔记视图即可看到导航栏效果。",
+        linkLabel: "查看官方说明与示例",
+      },
       matchNavigationWidthToLineLength: {
         name: "让导航栏宽度匹配行宽",
         desc: `启用后，导航栏的宽度会与笔记内容的行宽一致。
@@ -17,12 +36,10 @@ const zhCN: BaseMessage = {
       },
       displayOrderOfLinks: {
         name: "链接显示顺序",
-        desc: `使用前缀字符串（例如 emoji）指定链接显示顺序。
-例如：
-{periodic}、{property}、{folder}、🏠、⬆️、📌、🔗。
-链接会按这里列出的前缀顺序排序。
-"{periodic}"、"{property}" 和 "{folder}" 是特殊字符串，分别代表
-周期笔记链接、上一条/下一条/父级属性链接，以及文件夹链接。`,
+        desc: `使用前缀字符串（例如 emoji）指定链接显示顺序。例如：{periodic}、{property}、{folder}、🏠、⬆️、📌、🔗。链接会按这里列出的前缀顺序排序。`,
+        descTooltip:
+          '“{periodic}”、“{property}” 和 “{folder}” 是特殊占位符，分别代表周期笔记链接、上一条/下一条/父级属性链接，以及文件夹链接。',
+        tip: "多个前缀请使用英文逗号分隔。",
       },
       propertyNameForDisplayText: {
         name: "作为显示名称的属性名",
@@ -44,20 +61,21 @@ const zhCN: BaseMessage = {
         name: "折叠前缀",
         desc: `带有下列前缀（例如 emoji）的项目会自动折叠。
 你也可以在导航栏中点击前缀来折叠/取消折叠。`,
+        tip: "多个前缀请使用英文逗号分隔。",
       },
       mergePrefixes: {
         name: "合并前缀",
         desc: `指定要合并的前缀。例如设置 🔗 后，导航栏中的
-🔗[[Note 1]] 🔗[[Note 2]] 🔗[[Note 3]] 会合并为 🔗[[Note 1]] [[Note 2]] [[Note 3]]。
-多个前缀请使用英文逗号分隔。`,
+🔗[[Note 1]] 🔗[[Note 2]] 🔗[[Note 3]] 会合并为 🔗[[Note 1]] [[Note 2]] [[Note 3]]。`,
+        tip: "多个前缀请使用英文逗号分隔。",
       },
       displayLoadingMessage: {
         name: "显示加载提示",
-        desc: `链接加载过程中，在导航栏显示加载提示（「Loading...」）。`,
+        desc: `链接加载过程中，在导航栏显示加载提示（加载中……）。`,
       },
       displayPlaceholder: {
         name: "显示占位提示",
-        desc: `当没有可显示内容时，显示占位提示（「No links」）。`,
+        desc: `当没有可显示内容时，显示占位提示（无链接）。`,
       },
       confirmFileCreation: {
         name: "创建新文件时确认",
@@ -67,8 +85,8 @@ const zhCN: BaseMessage = {
       trimWhitespaceInInputFields: {
         name: "裁剪输入字段首尾空白",
         desc: `启用后，会自动去除下方设置中输入字符串的首尾空白。
-如果你需要保留空格，请关闭此选项。
-受影响设置：{affectedSettings}。`,
+如果你需要保留空格，请关闭此选项。`,
+        descTooltip: `受影响设置：{affectedSettings}。`,
         affectedSettings: [
           "链接显示顺序",
           "重复链接过滤优先级",
@@ -92,18 +110,18 @@ const zhCN: BaseMessage = {
       },
     },
     displayTargets: {
-      heading: "显示位置",
+      heading: "显示视图",
       inPanes: {
         name: "窗格",
         desc: `在笔记以窗格形式打开时显示导航栏。
-该设置作用于笔记容器（窗格）。要真正显示导航栏，
-还需要启用下方对应视图类型的选项。`,
+该设置作用于笔记容器（窗格）。`,
+        tip: "要真正显示导航栏，还需要启用下方对应视图类型的选项。",
       },
       inPagePreviews: {
         name: "页面预览",
         desc: `在页面预览中显示笔记时显示导航栏。
-该设置作用于笔记容器（页面预览）。
-要真正显示导航栏，还需要启用下方对应视图类型的选项。`,
+该设置作用于笔记容器（页面预览）。`,
+        tip: "要真正显示导航栏，还需要启用下方对应视图类型的选项。",
       },
       inMarkdownViews: {
         name: "Markdown 视图",
@@ -149,12 +167,12 @@ const zhCN: BaseMessage = {
 包含注释链接的笔记会显示在目标笔记导航栏的反向链接中。
 只要后续内容可被识别为链接（Wikilink 或 Markdown 链接），
 任意字符串（包括 emoji）都可以作为注释字符串。
-多个注释请用英文逗号分隔，例如 📌,🔗。
-{emojiPlaceholder} 可作为特殊占位符，表示任意单个 emoji。
-例如仅填写 {emojiPlaceholder} 时，所有前面带 emoji 的链接都会匹配。
-它也可以与其他条目混用，例如 {emojiPlaceholder}📌,🔗。
 如果不使用此功能，请留空。`,
+        tip: "多个注释请用英文逗号分隔，例如 📌,🔗。",
       },
+      annotationStringsForBacklinksTooltip: `{emojiPlaceholder} 可作为特殊占位符，表示任意单个 emoji。
+例如仅填写 {emojiPlaceholder} 时，所有前面带 emoji 的链接都会匹配。
+它也可以与其他条目混用，例如 {emojiPlaceholder}📌,🔗。`,
       annotationStringsForCurrentNote: {
         name: "当前笔记注释字符串",
         desc: `定义当前笔记中链接使用的注释字符串。
@@ -176,8 +194,8 @@ const zhCN: BaseMessage = {
       },
       advancedAnnotationStringsForCurrentNote: {
         name: "当前笔记高级注释字符串",
-        desc: `「当前笔记注释字符串」的高级版本。
-语法与「反向链接高级注释字符串」一致。`,
+        desc: `「当前笔记注释字符串」的高级版本。`,
+        tip: "语法与「反向链接高级注释字符串」一致。",
       },
       allowSpaceAfterAnnotationString: {
         name: "允许注释字符串与链接之间有空格",
@@ -192,14 +210,11 @@ const zhCN: BaseMessage = {
       heading: "属性链接",
       propertyMappings: {
         name: "属性映射",
-        desc: `定义属性映射。
-如果这里指定的文件属性指向某个笔记，
-该笔记会显示在导航栏中（也支持网站 URL）。
-每条映射由属性名和一个前缀字符串组成，
-当前缀链接出现在导航栏时会显示该字符串
-（如果想作为图标显示，可使用 emoji）。
-每行格式为 property_name:prefix。
-若前缀中需要冒号，请使用 \\: 转义。
+        desc: `定义从属性映射的链接关系。
+如果这里指定的文件属性指向某个笔记，该笔记会显示在导航栏中（也支持网站 URL）。
+每条映射由属性名和一个前缀字符串组成，当前缀链接出现在导航栏时会显示该字符串（如果想作为图标显示，可使用 emoji）。
+每行格式为 property_name:prefix。`,
+        tip: `若前缀中需要冒号，请使用 \\: 转义。
 前缀也可以为空字符串。
 如果不使用此功能，请留空。`,
         placeholder: "up:⬆️\nhome:🏠",
@@ -207,22 +222,22 @@ const zhCN: BaseMessage = {
       previousNotePropertyMappings: {
         name: "上一条笔记属性映射",
         desc: `输入用于指定上一条笔记的映射。这里指定的笔记会在导航栏中显示为
-< previous | parent | next >。
-语法与「属性映射」相同。`,
+< previous | parent | next >。`,
+        tip: "语法与「属性映射」相同。",
         placeholder: "previous:",
       },
       nextNotePropertyMappings: {
         name: "下一条笔记属性映射",
         desc: `输入用于指定下一条笔记的映射。这里指定的笔记会在导航栏中显示为
-< previous | parent | next >。
-语法与「属性映射」相同。`,
+< previous | parent | next >。`,
+        tip: "语法与「属性映射」相同。",
         placeholder: "next:",
       },
       parentNotePropertyMappings: {
         name: "父级笔记属性映射",
         desc: `输入用于指定父级笔记的映射。这里指定的笔记会在导航栏中显示为
-< previous | parent | next >。
-语法与「属性映射」相同。`,
+< previous | parent | next >。`,
+        tip: "语法与「属性映射」相同。",
         placeholder: "parent:\nup:",
       },
       linkDisplayStyle: {
@@ -245,6 +260,13 @@ const zhCN: BaseMessage = {
     },
     periodicNotes: {
       heading: "周期笔记链接",
+      sections: {
+        daily: "日记",
+        weekly: "周记",
+        monthly: "月记",
+        quarterly: "季记",
+        yearly: "年记",
+      },
       displayPrevNextInDailyNotes: {
         name: "在日记中显示上一条和下一条链接",
         desc: `使用此选项前，请先在 Daily Notes 插件或 Periodic Notes 插件中启用日记。`,
@@ -291,17 +313,17 @@ const zhCN: BaseMessage = {
       },
     },
     pinnedContent: {
-      heading: "置顶笔记内容",
+      heading: "置顶注释",
       annotationStrings: {
         name: "注释字符串",
         desc: `在导航栏中显示当前笔记的一部分内容。
-显示文本会从指定注释字符串后立即开始，
-一直持续到该行末尾。
+显示文本会从指定注释字符串后立即开始，一直持续到该行末尾。
 如果注释字符串后紧跟下方定义的起始和结束标记，
 则只显示这两个标记之间的内容。
-示例：📌[[note 1]]/[[note 2]](行末) → 📌[[note 1]]/[[note 2]]，
-📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]]。
-多个注释请用英文逗号分隔。`,
+示例：
+📌[[note 1]]/[[note 2]](行末) → 📌[[note 1]]/[[note 2]]，
+📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]]。`,
+        tip: "多个注释请用英文逗号分隔。",
         placeholder: "📌,🔗",
       },
       startMarker: { name: "起始标记", placeholder: "(" },
@@ -406,6 +428,10 @@ folder/*：folder 下一级所有文件夹）。`,
         desc: "显示在每个链接前的字符串（例如 emoji）。",
       },
       controls: {
+        rename: "重命名",
+        expand: "展开",
+        collapse: "折叠",
+        pinToTop: "置顶",
         moveUp: "上移",
         moveDown: "下移",
         remove: "移除",
@@ -437,7 +463,7 @@ folder/*：folder 下一级所有文件夹）。`,
     cancel: "取消",
   },
   ui: {
-    loading: "加载中...",
+    loading: "加载中……",
     noLinks: "无链接",
     collapsedCount: (itemCount: number) => `（${itemCount} 项）`,
   },

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -13,7 +13,6 @@ const zhCN: BaseMessage = {
     },
     sections: {
       display: "显示",
-      displayPosition: "显示位置",
       enabledViews: "显示视图",
     },
     threeWayDelimiterOptions: {
@@ -335,6 +334,11 @@ const zhCN: BaseMessage = {
     },
     folderLinks: {
       heading: "文件夹链接",
+      intro: {
+        desc: `创建文件夹链接规则，在导航栏中显示特定文件夹内的文件链接。
+你可以添加多个规则，每个规则都有自己的配置选项。`,
+        tip: `提示：点击规则名称可以重命名。`,
+      },
       folderSettingHeading: (index: number) => `文件夹设置 #${index}`,
       folderPaths: {
         name: "文件夹路径",
@@ -460,6 +464,7 @@ folder/*：folder 下一级所有文件夹）。`,
       `文件「${fileTitle}」不存在。确定要创建新笔记吗？`,
     create: "创建",
     createDontAskAgain: "创建（不再询问）",
+    save: "保存",
     cancel: "取消",
   },
   ui: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,147 @@
+import type { ThreeWayDelimiters } from "../ui/props";
+
+export interface BaseMessage {
+  setting: {
+    threeWayDelimiterOptions: Record<ThreeWayDelimiters, string>;
+    general: {
+      matchNavigationWidthToLineLength: { name: string; desc: string };
+      displayOrderOfLinks: { name: string; desc: string };
+      propertyNameForDisplayText: { name: string; desc: string; placeholder: string };
+      filterDuplicateLinks: { name: string; desc: string };
+      duplicateLinkFilteringPriority: { name: string; desc: string };
+      itemCollapsePrefixes: { name: string; desc: string };
+      mergePrefixes: { name: string; desc: string };
+      displayLoadingMessage: { name: string; desc: string };
+      displayPlaceholder: { name: string; desc: string };
+      confirmFileCreation: { name: string; desc: string };
+      trimWhitespaceInInputFields: {
+        name: string;
+        desc: string;
+        affectedSettings: string[];
+      };
+    };
+    displayTargets: {
+      heading: string;
+      inPanes: { name: string; desc: string };
+      inPagePreviews: { name: string; desc: string };
+      inMarkdownViews: { name: string; desc: string };
+      inImageViews: { name: string; desc: string };
+      inVideoViews: { name: string; desc: string };
+      inAudioViews: { name: string; desc: string };
+      inPdfViews: { name: string; desc: string };
+      inCanvasViews: { name: string; desc: string };
+      inBasesViews: { name: string; desc: string };
+      inOtherViews: { name: string; desc: string };
+    };
+    annotatedLinks: {
+      heading: string;
+      annotationStringsForBacklinks: { name: string; desc: string };
+      annotationStringsForCurrentNote: { name: string; desc: string };
+      hidePrefixes: { name: string; desc: string };
+      advancedAnnotationStringsForBacklinks: {
+        name: string;
+        desc: string;
+        placeholder: string;
+      };
+      advancedAnnotationStringsForCurrentNote: { name: string; desc: string };
+      allowSpaceAfterAnnotationString: { name: string; desc: string };
+      ignoreVariationSelectors: { name: string; desc: string };
+    };
+    propertyLinks: {
+      heading: string;
+      propertyMappings: { name: string; desc: string; placeholder: string };
+      previousNotePropertyMappings: { name: string; desc: string; placeholder: string };
+      nextNotePropertyMappings: { name: string; desc: string; placeholder: string };
+      parentNotePropertyMappings: { name: string; desc: string; placeholder: string };
+      linkDisplayStyle: { name: string; desc: string };
+      implicitReciprocalPropertyPairs: { name: string; desc: string; placeholder: string };
+    };
+    periodicNotes: {
+      heading: string;
+      displayPrevNextInDailyNotes: { name: string; desc: string };
+      parentForDailyNotes: { name: string };
+      displayPrevNextInWeeklyNotes: { name: string; desc: string };
+      parentForWeeklyNotes: { name: string };
+      displayPrevNextInMonthlyNotes: { name: string; desc: string };
+      parentForMonthlyNotes: { name: string };
+      displayPrevNextInQuarterlyNotes: { name: string; desc: string };
+      parentForQuarterlyNotes: { name: string };
+      displayPrevNextInYearlyNotes: { name: string; desc: string };
+      linkDisplayStyle: { name: string; desc: string };
+      linkPrefix: { name: string; desc: string };
+      granularityOptions: {
+        none: string;
+        week: string;
+        month: string;
+        quarter: string;
+        year: string;
+      };
+    };
+    pinnedContent: {
+      heading: string;
+      annotationStrings: { name: string; desc: string; placeholder: string };
+      startMarker: { name: string; placeholder: string };
+      endMarker: { name: string; placeholder: string };
+      ignoreCodeBlocks: { name: string; desc: string };
+    };
+    folderLinks: {
+      heading: string;
+      folderSettingHeading: (index: number) => string;
+      folderPaths: { name: string; desc: string; placeholder: string };
+      excludedFolderPaths: { name: string; desc: string; placeholder: string };
+      recursive: { name: string; desc: string };
+      includePatterns: { name: string; desc: string; placeholder: string };
+      excludePatterns: { name: string; desc: string; placeholder: string };
+      enableRegex: { name: string; desc: string };
+      filterBy: {
+        name: string;
+        desc: string;
+        options: { filename: string; property: string };
+      };
+      propertyNameToFilterBy: { name: string; desc: string };
+      sortOrder: { name: string; options: { asc: string; desc: string } };
+      sortBy: {
+        name: string;
+        options: { filename: string; created: string; modified: string; property: string };
+      };
+      propertyNameToSortBy: { name: string; desc: string };
+      maxLinks: { name: string; desc: string };
+      pathToParentNote: { name: string; placeholder: string };
+      linkDisplayStyle: { name: string; desc: string };
+      linkPrefix: { name: string; desc: string };
+      controls: {
+        moveUp: string;
+        moveDown: string;
+        remove: string;
+        addFolderSetting: string;
+      };
+    };
+  };
+  command: {
+    openPreviousPropertyLink: string;
+    openNextPropertyLink: string;
+    openParentPropertyLink: string;
+    openPreviousPeriodicNote: string;
+    openNextPeriodicNote: string;
+    openParentPeriodicNote: string;
+    openPreviousFolderLink: string;
+    openNextFolderLink: string;
+    openParentFolderLink: string;
+    openPreviousAny: string;
+    openNextAny: string;
+    openParentAny: string;
+    toggleMatchNavigationWidth: string;
+  };
+  modal: {
+    createNewNote: string;
+    fileNotExist: (fileTitle: string) => string;
+    create: string;
+    createDontAskAgain: string;
+    cancel: string;
+  };
+  ui: {
+    loading: string;
+    noLinks: string;
+    collapsedCount: (itemCount: number) => string;
+  };
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -13,7 +13,6 @@ export interface BaseMessage {
     };
     sections: {
       display: string;
-      displayPosition: string;
       enabledViews: string;
     };
     threeWayDelimiterOptions: Record<ThreeWayDelimiters, string>;
@@ -125,6 +124,7 @@ export interface BaseMessage {
     };
     folderLinks: {
       heading: string;
+      intro: { desc: string; tip: string };
       folderSettingHeading: (index: number) => string;
       folderPaths: { name: string; desc: string; placeholder: string };
       excludedFolderPaths: { name: string; desc: string; placeholder: string };
@@ -180,6 +180,7 @@ export interface BaseMessage {
     fileNotExist: (fileTitle: string) => string;
     create: string;
     createDontAskAgain: string;
+    save: string;
     cancel: string;
   };
   ui: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2,28 +2,44 @@ import type { ThreeWayDelimiters } from "../ui/props";
 
 export interface BaseMessage {
   setting: {
+    tabs: {
+      common: string;
+      enabledViews: string;
+      annotatedLinks: string;
+      propertyLinks: string;
+      periodicNotes: string;
+      pinnedContent: string;
+      folderLinks: string;
+    };
+    sections: {
+      display: string;
+      displayPosition: string;
+      enabledViews: string;
+    };
     threeWayDelimiterOptions: Record<ThreeWayDelimiters, string>;
     general: {
+      pluginGuide: { name: string; desc: string; linkLabel: string };
       matchNavigationWidthToLineLength: { name: string; desc: string };
-      displayOrderOfLinks: { name: string; desc: string };
+      displayOrderOfLinks: { name: string; desc: string; descTooltip: string; tip: string };
       propertyNameForDisplayText: { name: string; desc: string; placeholder: string };
       filterDuplicateLinks: { name: string; desc: string };
       duplicateLinkFilteringPriority: { name: string; desc: string };
-      itemCollapsePrefixes: { name: string; desc: string };
-      mergePrefixes: { name: string; desc: string };
+      itemCollapsePrefixes: { name: string; desc: string; tip: string };
+      mergePrefixes: { name: string; desc: string; tip: string };
       displayLoadingMessage: { name: string; desc: string };
       displayPlaceholder: { name: string; desc: string };
       confirmFileCreation: { name: string; desc: string };
       trimWhitespaceInInputFields: {
         name: string;
         desc: string;
+        descTooltip: string;
         affectedSettings: string[];
       };
     };
     displayTargets: {
       heading: string;
-      inPanes: { name: string; desc: string };
-      inPagePreviews: { name: string; desc: string };
+      inPanes: { name: string; desc: string; tip: string };
+      inPagePreviews: { name: string; desc: string; tip: string };
       inMarkdownViews: { name: string; desc: string };
       inImageViews: { name: string; desc: string };
       inVideoViews: { name: string; desc: string };
@@ -35,7 +51,8 @@ export interface BaseMessage {
     };
     annotatedLinks: {
       heading: string;
-      annotationStringsForBacklinks: { name: string; desc: string };
+      annotationStringsForBacklinks: { name: string; desc: string; tip: string };
+      annotationStringsForBacklinksTooltip: string;
       annotationStringsForCurrentNote: { name: string; desc: string };
       hidePrefixes: { name: string; desc: string };
       advancedAnnotationStringsForBacklinks: {
@@ -43,21 +60,43 @@ export interface BaseMessage {
         desc: string;
         placeholder: string;
       };
-      advancedAnnotationStringsForCurrentNote: { name: string; desc: string };
+      advancedAnnotationStringsForCurrentNote: { name: string; desc: string; tip: string };
       allowSpaceAfterAnnotationString: { name: string; desc: string };
       ignoreVariationSelectors: { name: string; desc: string };
     };
     propertyLinks: {
       heading: string;
-      propertyMappings: { name: string; desc: string; placeholder: string };
-      previousNotePropertyMappings: { name: string; desc: string; placeholder: string };
-      nextNotePropertyMappings: { name: string; desc: string; placeholder: string };
-      parentNotePropertyMappings: { name: string; desc: string; placeholder: string };
+      propertyMappings: { name: string; desc: string; tip: string; placeholder: string };
+      previousNotePropertyMappings: {
+        name: string;
+        desc: string;
+        tip: string;
+        placeholder: string;
+      };
+      nextNotePropertyMappings: {
+        name: string;
+        desc: string;
+        tip: string;
+        placeholder: string;
+      };
+      parentNotePropertyMappings: {
+        name: string;
+        desc: string;
+        tip: string;
+        placeholder: string;
+      };
       linkDisplayStyle: { name: string; desc: string };
       implicitReciprocalPropertyPairs: { name: string; desc: string; placeholder: string };
     };
     periodicNotes: {
       heading: string;
+      sections: {
+        daily: string;
+        weekly: string;
+        monthly: string;
+        quarterly: string;
+        yearly: string;
+      };
       displayPrevNextInDailyNotes: { name: string; desc: string };
       parentForDailyNotes: { name: string };
       displayPrevNextInWeeklyNotes: { name: string; desc: string };
@@ -79,7 +118,7 @@ export interface BaseMessage {
     };
     pinnedContent: {
       heading: string;
-      annotationStrings: { name: string; desc: string; placeholder: string };
+      annotationStrings: { name: string; desc: string; tip: string; placeholder: string };
       startMarker: { name: string; placeholder: string };
       endMarker: { name: string; placeholder: string };
       ignoreCodeBlocks: { name: string; desc: string };
@@ -110,6 +149,10 @@ export interface BaseMessage {
       linkDisplayStyle: { name: string; desc: string };
       linkPrefix: { name: string; desc: string };
       controls: {
+        rename: string;
+        expand: string;
+        collapse: string;
+        pinToTop: string;
         moveUp: string;
         moveDown: string;
         remove: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ import {
 import { EMOJI_ANNOTATION_PLACEHOLDER } from "./annotatedLink";
 import type { ThreeWayDelimiters } from "./ui/props";
 import { deepCopy } from "./utils";
+import { t } from "./i18n/i18n";
 
 export interface NavLinkHeaderSettings {
   version: string;
@@ -404,25 +405,16 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
 
-    const threeWayDelimiterOptions = {
-      "full": "Full",
-      "full-double-separator": "Full (double separator)",
-      "separator": "Separator",
-      "double-separator": "Double separator",
-      "none": "None",
-    } satisfies Record<ThreeWayDelimiters, string>;
+    const msg = t().setting;
+
+    const threeWayDelimiterOptions =
+      msg.threeWayDelimiterOptions satisfies Record<ThreeWayDelimiters, string>;
 
     new SettingGroup(containerEl)
       .addSetting((setting) => {
         setting
-          .setName("Match navigation header width to line length")
-          .setDesc(
-            `
-              If enabled, the width of the navigation header will match the line length of the note.
-              Here, "line length" refers to the width defined when Obsidian's "Readable line length"
-              option is enabled.
-            `,
-          )
+          .setName(msg.general.matchNavigationWidthToLineLength.name)
+          .setDesc(msg.general.matchNavigationWidthToLineLength.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.matchNavigationWidthToLineLength)
@@ -434,18 +426,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display order of links")
+          .setName(msg.general.displayOrderOfLinks.name)
           .setDesc(
-            `
-              Specify the display order of links using prefix strings (e.g., emojis).
-              For example:
-              ${DISPLAY_ORDER_PLACEHOLDER_PERIODIC}, ${DISPLAY_ORDER_PLACEHOLDER_PROPERTY},
-              ${DISPLAY_ORDER_PLACEHOLDER_FOLDER}, 🏠, ⬆️, 📌, 🔗.
-              Links are sorted according to the order of the prefix strings listed here.
-              "${DISPLAY_ORDER_PLACEHOLDER_PERIODIC}", "${DISPLAY_ORDER_PLACEHOLDER_PROPERTY}",
-              and "${DISPLAY_ORDER_PLACEHOLDER_FOLDER}" are special strings that represent periodic
-              note links, previous/next/parent property links, and folder links, respectively.
-            `,
+            msg.general.displayOrderOfLinks.desc
+              .replaceAll("{periodic}", DISPLAY_ORDER_PLACEHOLDER_PERIODIC)
+              .replaceAll("{property}", DISPLAY_ORDER_PLACEHOLDER_PROPERTY)
+              .replaceAll("{folder}", DISPLAY_ORDER_PLACEHOLDER_FOLDER),
           )
           .addText((text) => {
             const order = this.plugin.settingsUnderChange.displayOrderOfLinks.join(",");
@@ -461,17 +447,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Property name to specify display text")
-          .setDesc(
-            `
-              If you want to use file properties to specify the note's display text, set the
-              property name to this field. Leave this field blank if you are not using this feature.
-            `,
-          )
+          .setName(msg.general.propertyNameForDisplayText.name)
+          .setDesc(msg.general.propertyNameForDisplayText.desc)
           .addText((text) => {
             text
               .setValue(this.plugin.settingsUnderChange.propertyNameForDisplayText)
-              .setPlaceholder("title")
+              .setPlaceholder(msg.general.propertyNameForDisplayText.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.propertyNameForDisplayText = value.trim();
                 this.plugin.triggerSettingsChangedDebounced();
@@ -480,13 +461,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Filter duplicate links")
-          .setDesc(
-            `
-              Filter out duplicates when multiple links with the same destination are detected.
-              This setting does not apply to prev/next/parent-type links and pinned note contents.
-            `,
-          )
+          .setName(msg.general.filterDuplicateLinks.name)
+          .setDesc(msg.general.filterDuplicateLinks.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.filterDuplicateNotes)
@@ -498,14 +474,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Duplicate link filtering priority")
-          .setDesc(
-            `
-              Specify the filtering priority.
-              For example, if you specify 🏠,⬆️,📌,🔗 here,
-              links with "🏠" will be displayed with the highest priority.
-            `,
-          )
+          .setName(msg.general.duplicateLinkFilteringPriority.name)
+          .setDesc(msg.general.duplicateLinkFilteringPriority.desc)
           .addText((text) => {
             const priority =
               this.plugin.settingsUnderChange.duplicateNoteFilteringPriority.join(",");
@@ -521,14 +491,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Item collapse prefixes")
-          .setDesc(
-            `
-              Items whose prefix (e.g., an emoji) matches any of these strings will be collapsed
-              into a single entry.
-              Prefixes can also be added or removed by clicking them in the navigation header.
-            `,
-          )
+          .setName(msg.general.itemCollapsePrefixes.name)
+          .setDesc(msg.general.itemCollapsePrefixes.desc)
           .addText((text) => {
             const prefixes = this.plugin.settingsUnderChange.itemCollapsePrefixes.join(",");
             text.setValue(prefixes).onChange((value) => {
@@ -543,15 +507,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Merge prefixes")
-          .setDesc(
-            `
-              Specify the prefixes to merge. For example, setting 🔗 will merge links like
-              🔗[[Note 1]] 🔗[[Note 2]] 🔗[[Note 3]] into 🔗[[Note 1]] [[Note 2]] [[Note 3]]
-              in the navigation header.
-              Multiple prefixes can be specified by separating them with commas.
-            `,
-          )
+          .setName(msg.general.mergePrefixes.name)
+          .setDesc(msg.general.mergePrefixes.desc)
           .addText((text) => {
             const prefixes = this.plugin.settingsUnderChange.mergePrefixes.join(",");
             text.setValue(prefixes).onChange((value) => {
@@ -566,13 +523,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display loading message")
-          .setDesc(
-            `
-              Display a loading message ("Loading...") in the navigation header
-              while links are being loaded.
-            `,
-          )
+          .setName(msg.general.displayLoadingMessage.name)
+          .setDesc(msg.general.displayLoadingMessage.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayLoadingMessage)
@@ -584,12 +536,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display placeholder")
-          .setDesc(
-            `
-              Display a placeholder ("No links") when there is nothing to display.
-            `,
-          )
+          .setName(msg.general.displayPlaceholder.name)
+          .setDesc(msg.general.displayPlaceholder.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayPlaceholder)
@@ -601,13 +549,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Confirm when creating a new file")
-          .setDesc(
-            `
-              Display a confirmation dialog when a new file is created.
-              This option is currently only used for periodic notes.
-            `,
-          )
+          .setName(msg.general.confirmFileCreation.name)
+          .setDesc(msg.general.confirmFileCreation.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.confirmFileCreation)
@@ -618,38 +561,17 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       })
       .addSetting((setting) => {
-        const affectedSettings = [
-          "Display order of links",
-          "Duplicate link filtering priority",
-          "Item collapse prefixes",
-          "Merge prefixes",
-          "Annotation strings for backlinks",
-          "Annotation strings for current note",
-          "Advanced annotation strings for backlinks",
-          "Advanced annotation strings for current note",
-          "Previous note property mappings",
-          "Next note property mappings",
-          "Parent note property mappings",
-          "Link prefix (Periodic note links)",
-          "Annotation strings (Pinned note content)",
-          "Start marker",
-          "End marker",
-          "Include patterns",
-          "Exclude patterns",
-          "Link prefix (Folder links)",
-        ]
+        const affectedSettings = msg.general.trimWhitespaceInInputFields.affectedSettings
           .map((s) => `"${s}"`)
           .join(", ");
 
         setting
-          .setName("Trim whitespace in input fields")
+          .setName(msg.general.trimWhitespaceInInputFields.name)
           .setDesc(
-            `
-              When enabled, leading and trailing whitespace will be trimmed from the strings
-              entered in the settings below.
-              Disable this option if you want to include spaces intentionally.
-              Affected settings: ${affectedSettings}.
-            `,
+            msg.general.trimWhitespaceInInputFields.desc.replace(
+              "{affectedSettings}",
+              affectedSettings,
+            ),
           )
           .addToggle((toggle) => {
             toggle
@@ -662,17 +584,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(containerEl)
-      .setHeading("Display targets")
+      .setHeading(msg.displayTargets.heading)
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in panes")
-          .setDesc(
-            `
-              Show navigation header when notes are opened in panes.
-              This setting applies to note containers (panes). To show the navigation header,
-              also enable view-specific options below.
-            `,
-          )
+          .setName(msg.displayTargets.inPanes.name)
+          .setDesc(msg.displayTargets.inPanes.desc)
           .addToggle((toggle) => {
             toggle.setValue(this.plugin.settingsUnderChange.displayInLeaves).onChange((value) => {
               this.plugin.settingsUnderChange.displayInLeaves = value;
@@ -682,14 +598,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in page previews")
-          .setDesc(
-            `
-              Show navigation header when notes are shown in page previews.
-              This setting applies to note containers (page previews).
-              To show the navigation header, also enable view-specific options below.
-            `,
-          )
+          .setName(msg.displayTargets.inPagePreviews.name)
+          .setDesc(msg.displayTargets.inPagePreviews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInHoverPopovers)
@@ -701,8 +611,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in Markdown views")
-          .setDesc("Show navigation header when viewing Markdown documents.")
+          .setName(msg.displayTargets.inMarkdownViews.name)
+          .setDesc(msg.displayTargets.inMarkdownViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInMarkdownViews)
@@ -714,8 +624,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in Image views")
-          .setDesc("Show navigation header when viewing images.")
+          .setName(msg.displayTargets.inImageViews.name)
+          .setDesc(msg.displayTargets.inImageViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInImageViews)
@@ -727,8 +637,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in Video views")
-          .setDesc("Show navigation header when viewing videos.")
+          .setName(msg.displayTargets.inVideoViews.name)
+          .setDesc(msg.displayTargets.inVideoViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInVideoViews)
@@ -740,8 +650,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in Audio views")
-          .setDesc("Show navigation header when viewing audio.")
+          .setName(msg.displayTargets.inAudioViews.name)
+          .setDesc(msg.displayTargets.inAudioViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInAudioViews)
@@ -753,8 +663,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in PDF views")
-          .setDesc("Show navigation header when viewing PDFs.")
+          .setName(msg.displayTargets.inPdfViews.name)
+          .setDesc(msg.displayTargets.inPdfViews.desc)
           .addToggle((toggle) => {
             toggle.setValue(this.plugin.settingsUnderChange.displayInPdfViews).onChange((value) => {
               this.plugin.settingsUnderChange.displayInPdfViews = value;
@@ -764,8 +674,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in Canvas views")
-          .setDesc("Show navigation header when viewing Canvas.")
+          .setName(msg.displayTargets.inCanvasViews.name)
+          .setDesc(msg.displayTargets.inCanvasViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInCanvasViews)
@@ -777,8 +687,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in Bases views")
-          .setDesc("Show navigation header when viewing Bases.")
+          .setName(msg.displayTargets.inBasesViews.name)
+          .setDesc(msg.displayTargets.inBasesViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInBasesViews)
@@ -790,13 +700,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display navigation header in other views")
-          .setDesc(
-            `
-          Show navigation header in other views (such as views introduced by community plugins).
-          This may not work depending on the view type.
-        `,
-          )
+          .setName(msg.displayTargets.inOtherViews.name)
+          .setDesc(msg.displayTargets.inOtherViews.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.displayInOtherViews)
@@ -808,25 +713,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(containerEl)
-      .setHeading("Annotated links")
+      .setHeading(msg.annotatedLinks.heading)
       .addSetting((setting) => {
         setting
-          .setName("Annotation strings for backlinks")
+          .setName(msg.annotatedLinks.annotationStringsForBacklinks.name)
           .setDesc(
-            `
-              Define the annotation strings.
-              If one of the annotation strings (e.g., emojis) is placed immediately before
-              a link in a note content, the link is recognized as an annotated link.
-              Notes with annotated links appear as backlinks in the navigation header of the
-              destination note. Any string, including emoji, is acceptable as long as the following
-              link is recognized as a link (Wikilink or Markdown link).
-              To specify multiple annotations, separate them with commas. e.g., 📌,🔗.
-              ${EMOJI_ANNOTATION_PLACEHOLDER} can be used as a special placeholder
-              that represents any single emoji. For example, if you specify only
-              ${EMOJI_ANNOTATION_PLACEHOLDER}, all links preceded by an emoji will be matched.
-              It can also be mixed with other entries, e.g., ${EMOJI_ANNOTATION_PLACEHOLDER}📌,🔗.
-              Leave this field blank if you are not using this feature.
-            `,
+            msg.annotatedLinks.annotationStringsForBacklinks.desc.replaceAll(
+              "{emojiPlaceholder}",
+              EMOJI_ANNOTATION_PLACEHOLDER,
+            ),
           )
           .addText((text) => {
             const annotations =
@@ -843,14 +738,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Annotation strings for current note")
-          .setDesc(
-            `
-              Define the annotation strings for links in the current note.
-              This setting works the same way as "Annotation strings for backlinks",
-              but applies to links in the current note.
-            `,
-          )
+          .setName(msg.annotatedLinks.annotationStringsForCurrentNote.name)
+          .setDesc(msg.annotatedLinks.annotationStringsForCurrentNote.desc)
           .addText((text) => {
             const annotations =
               this.plugin.settingsUnderChange.annotationStringsForCurrentNote.join(",");
@@ -866,8 +755,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Hide prefixes in the navigation header")
-          .setDesc("If enabled, prefixes (e.g., emojis) will be hidden in the navigation header.")
+          .setName(msg.annotatedLinks.hidePrefixes.name)
+          .setDesc(msg.annotatedLinks.hidePrefixes.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.hideAnnotatedLinkPrefix)
@@ -879,18 +768,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Advanced annotation strings for backlinks")
-          .setDesc(
-            `
-              An advanced version of "Annotation strings for backlinks".
-              This setting allows regular expressions to be used as
-              annotation strings and any prefix (e.g., an emoji) to be assigned for display
-              in the navigation header.
-              Enter one mapping per line using the format regex:prefix.
-              To include a colon in the prefix, escape it as "\\:".
-              An empty string is also acceptable as a prefix.
-            `,
-          )
+          .setName(msg.annotatedLinks.advancedAnnotationStringsForBacklinks.name)
+          .setDesc(msg.annotatedLinks.advancedAnnotationStringsForBacklinks.desc)
           .addTextArea((text) => {
             const annotations =
               this.plugin.settingsUnderChange.advancedAnnotationStringsForBacklinks
@@ -900,7 +779,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                 .join("\n");
             text
               .setValue(annotations)
-              .setPlaceholder("📌:🔗\n(?:^|\\n)-:\n\\[\\[E\\]\\]:🔗")
+              .setPlaceholder(msg.annotatedLinks.advancedAnnotationStringsForBacklinks.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.advancedAnnotationStringsForBacklinks =
                   parseAdvancedAnnotationStrings(value, this.plugin.settings.trimStringsInSettings);
@@ -910,13 +789,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Advanced annotation strings for current note")
-          .setDesc(
-            `
-              An advanced version of "Annotation strings for current note".
-              The syntax is the same as that of "Advanced annotation strings for backlinks".
-            `,
-          )
+          .setName(msg.annotatedLinks.advancedAnnotationStringsForCurrentNote.name)
+          .setDesc(msg.annotatedLinks.advancedAnnotationStringsForCurrentNote.desc)
           .addTextArea((text) => {
             const annotations =
               this.plugin.settingsUnderChange.advancedAnnotationStringsForCurrentNote
@@ -933,13 +807,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Allow a space between the annotation string and the link")
-          .setDesc(
-            `
-              If enabled, a link will still be recognized as an annotated link even if there is a
-              space between the annotation string and the link.
-            `,
-          )
+          .setName(msg.annotatedLinks.allowSpaceAfterAnnotationString.name)
+          .setDesc(msg.annotatedLinks.allowSpaceAfterAnnotationString.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.allowSpaceAfterAnnotationString)
@@ -951,10 +820,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Ignore variation selectors")
-          .setDesc(
-            "If enabled, emoji variation selectors (VS15/VS16) are ignored when matching links.",
-          )
+          .setName(msg.annotatedLinks.ignoreVariationSelectors.name)
+          .setDesc(msg.annotatedLinks.ignoreVariationSelectors.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.ignoreVariationSelectors)
@@ -966,32 +833,18 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(containerEl)
-      .setHeading("Property links")
+      .setHeading(msg.propertyLinks.heading)
       .addSetting((setting) => {
         setting
-          .setName("Property mappings")
-          .setDesc(
-            `
-              Define the property mappings.
-              If the file property specified here points to a specific note,
-              that note will be displayed in the navigation header
-              (URLs to the website are also supported).
-              Each mapping consists of a property name and a string that will
-              be placed at the beginning of the link when it appears in the navigation header
-              (use emojis in this string if you want it to appear like an icon).
-              Each line should be in the format property_name:prefix.
-              To include a colon in the prefix, escape it as \\:.
-              An empty string is also acceptable as a prefix.
-              Leave this field blank if you are not using this feature.
-            `,
-          )
+          .setName(msg.propertyLinks.propertyMappings.name)
+          .setDesc(msg.propertyLinks.propertyMappings.desc)
           .addTextArea((text) => {
             const mappings = this.plugin.settingsUnderChange.propertyMappings
               .map((mapping) => `${mapping.property}:${mapping.prefix.replace(/:/g, "\\:")}`)
               .join("\n");
             text
               .setValue(mappings)
-              .setPlaceholder("up:⬆️\nhome:🏠")
+              .setPlaceholder(msg.propertyLinks.propertyMappings.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.propertyMappings = parsePropertyMappings(
                   value,
@@ -1003,21 +856,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Previous note property mappings")
-          .setDesc(
-            `
-              Enter the mapping that specifies the previous note. The note specified here will
-              appear in the navigation header as < previous | parent | next >.
-              The syntax is the same as "Property mappings".
-            `,
-          )
+          .setName(msg.propertyLinks.previousNotePropertyMappings.name)
+          .setDesc(msg.propertyLinks.previousNotePropertyMappings.desc)
           .addTextArea((text) => {
             const mappings = this.plugin.settingsUnderChange.previousLinkPropertyMappings
               .map((mapping) => `${mapping.property}:${mapping.prefix.replace(/:/g, "\\:")}`)
               .join("\n");
             text
               .setValue(mappings)
-              .setPlaceholder("previous:")
+              .setPlaceholder(msg.propertyLinks.previousNotePropertyMappings.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.previousLinkPropertyMappings =
                   parsePropertyMappings(value, this.plugin.settings.trimStringsInSettings);
@@ -1027,21 +874,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Next note property mappings")
-          .setDesc(
-            `
-              Enter the mapping that specifies the next note. The note specified here will appear
-              in the navigation header as < previous | parent | next >.
-              The syntax is the same as "Property mappings".
-            `,
-          )
+          .setName(msg.propertyLinks.nextNotePropertyMappings.name)
+          .setDesc(msg.propertyLinks.nextNotePropertyMappings.desc)
           .addTextArea((text) => {
             const mappings = this.plugin.settingsUnderChange.nextLinkPropertyMappings
               .map((mapping) => `${mapping.property}:${mapping.prefix.replace(/:/g, "\\:")}`)
               .join("\n");
             text
               .setValue(mappings)
-              .setPlaceholder("next:")
+              .setPlaceholder(msg.propertyLinks.nextNotePropertyMappings.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.nextLinkPropertyMappings = parsePropertyMappings(
                   value,
@@ -1053,21 +894,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Parent note property mappings")
-          .setDesc(
-            `
-              Enter the mapping that specifies the parent note. The note specified here will appear
-              in the navigation header as < previous | parent | next >.
-              The syntax is the same as "Property mappings".
-            `,
-          )
+          .setName(msg.propertyLinks.parentNotePropertyMappings.name)
+          .setDesc(msg.propertyLinks.parentNotePropertyMappings.desc)
           .addTextArea((text) => {
             const mappings = this.plugin.settingsUnderChange.parentLinkPropertyMappings
               .map((mapping) => `${mapping.property}:${mapping.prefix.replace(/:/g, "\\:")}`)
               .join("\n");
             text
               .setValue(mappings)
-              .setPlaceholder("parent:\nup:")
+              .setPlaceholder(msg.propertyLinks.parentNotePropertyMappings.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.parentLinkPropertyMappings = parsePropertyMappings(
                   value,
@@ -1079,17 +914,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Link display style")
-          .setDesc(
-            `
-              Specify the display style of prev/next/parent links in the navigation header.
-              Full: < previous | parent | next >,
-              Full (double separator): < previous || parent || next >,
-              Separator: previous | parent | next,
-              Double separator: previous || parent || next,
-              None: previous parent next.
-            `,
-          )
+          .setName(msg.propertyLinks.linkDisplayStyle.name)
+          .setDesc(msg.propertyLinks.linkDisplayStyle.desc)
           .addDropdown((dropdown) => {
             dropdown
               .addOptions(threeWayDelimiterOptions)
@@ -1103,23 +929,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Implicit reciprocal property pairs")
-          .setDesc(
-            `
-              Specify pairs of property names here to implicitly create reciprocal links
-              in the navigation header. For example, if you enter prev:next here,
-              when Note A has a property "next: [[Note B]]", Note B will be treated as if
-              it also had "prev: [[Note A]]" even if it isn't explicitly set.
-              Enter one pair per line.
-            `,
-          )
+          .setName(msg.propertyLinks.implicitReciprocalPropertyPairs.name)
+          .setDesc(msg.propertyLinks.implicitReciprocalPropertyPairs.desc)
           .addTextArea((text) => {
             const pairs = this.plugin.settingsUnderChange.implicitReciprocalPropertyPairs
               .map((pair) => `${pair.propertyA}:${pair.propertyB}`)
               .join("\n");
             text
               .setValue(pairs)
-              .setPlaceholder("prev:next\nparent:child")
+              .setPlaceholder(msg.propertyLinks.implicitReciprocalPropertyPairs.placeholder)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.implicitReciprocalPropertyPairs =
                   parsePropertyPairs(value);
@@ -1129,16 +947,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(containerEl)
-      .setHeading("Periodic note links")
+      .setHeading(msg.periodicNotes.heading)
       .addSetting((setting) => {
         setting
-          .setName("Display previous and next links in daily notes")
-          .setDesc(
-            `
-              To use this option, daily notes must be enabled
-              in Daily Notes plugin or Periodic Notes plugin.
-            `,
-          )
+          .setName(msg.periodicNotes.displayPrevNextInDailyNotes.name)
+          .setDesc(msg.periodicNotes.displayPrevNextInDailyNotes.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.prevNextLinksEnabledInDailyNotes)
@@ -1149,14 +962,14 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       })
       .addSetting((setting) => {
-        setting.setName("Parent for daily notes").addDropdown((dropdown) => {
+        setting.setName(msg.periodicNotes.parentForDailyNotes.name).addDropdown((dropdown) => {
           dropdown
             .addOptions({
-              none: "None",
-              week: "Weekly",
-              month: "Monthly",
-              quarter: "Quarterly",
-              year: "Yearly",
+              none: msg.periodicNotes.granularityOptions.none,
+              week: msg.periodicNotes.granularityOptions.week,
+              month: msg.periodicNotes.granularityOptions.month,
+              quarter: msg.periodicNotes.granularityOptions.quarter,
+              year: msg.periodicNotes.granularityOptions.year,
             })
             .setValue(this.plugin.settingsUnderChange.parentLinkGranularityInDailyNotes ?? "none")
             .onChange((value) => {
@@ -1168,8 +981,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display previous and next links in weekly notes")
-          .setDesc("To use this option, weekly notes must be enabled in Periodic Notes plugin.")
+          .setName(msg.periodicNotes.displayPrevNextInWeeklyNotes.name)
+          .setDesc(msg.periodicNotes.displayPrevNextInWeeklyNotes.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.prevNextLinksEnabledInWeeklyNotes)
@@ -1180,13 +993,13 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       })
       .addSetting((setting) => {
-        setting.setName("Parent for weekly notes").addDropdown((dropdown) => {
+        setting.setName(msg.periodicNotes.parentForWeeklyNotes.name).addDropdown((dropdown) => {
           dropdown
             .addOptions({
-              none: "None",
-              month: "Monthly",
-              quarter: "Quarterly",
-              year: "Yearly",
+              none: msg.periodicNotes.granularityOptions.none,
+              month: msg.periodicNotes.granularityOptions.month,
+              quarter: msg.periodicNotes.granularityOptions.quarter,
+              year: msg.periodicNotes.granularityOptions.year,
             })
             .setValue(this.plugin.settingsUnderChange.parentLinkGranularityInWeeklyNotes ?? "none")
             .onChange((value) => {
@@ -1198,8 +1011,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display previous and next links in monthly notes")
-          .setDesc("To use this option, monthly notes must be enabled in Periodic Notes plugin.")
+          .setName(msg.periodicNotes.displayPrevNextInMonthlyNotes.name)
+          .setDesc(msg.periodicNotes.displayPrevNextInMonthlyNotes.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.prevNextLinksEnabledInMonthlyNotes)
@@ -1210,12 +1023,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       })
       .addSetting((setting) => {
-        setting.setName("Parent for monthly notes").addDropdown((dropdown) => {
+        setting.setName(msg.periodicNotes.parentForMonthlyNotes.name).addDropdown((dropdown) => {
           dropdown
             .addOptions({
-              none: "None",
-              quarter: "Quarterly",
-              year: "Yearly",
+              none: msg.periodicNotes.granularityOptions.none,
+              quarter: msg.periodicNotes.granularityOptions.quarter,
+              year: msg.periodicNotes.granularityOptions.year,
             })
             .setValue(this.plugin.settingsUnderChange.parentLinkGranularityInMonthlyNotes ?? "none")
             .onChange((value) => {
@@ -1227,8 +1040,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display previous and next links in quarterly notes")
-          .setDesc("To use this option, quarterly notes must be enabled in Periodic Notes plugin.")
+          .setName(msg.periodicNotes.displayPrevNextInQuarterlyNotes.name)
+          .setDesc(msg.periodicNotes.displayPrevNextInQuarterlyNotes.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.prevNextLinksEnabledInQuarterlyNotes)
@@ -1239,11 +1052,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       })
       .addSetting((setting) => {
-        setting.setName("Parent for quarterly notes").addDropdown((dropdown) => {
+        setting.setName(msg.periodicNotes.parentForQuarterlyNotes.name).addDropdown((dropdown) => {
           dropdown
             .addOptions({
-              none: "None",
-              year: "Yearly",
+              none: msg.periodicNotes.granularityOptions.none,
+              year: msg.periodicNotes.granularityOptions.year,
             })
             .setValue(
               this.plugin.settingsUnderChange.parentLinkGranularityInQuarterlyNotes ?? "none",
@@ -1257,8 +1070,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Display previous and next links in yearly notes")
-          .setDesc("To use this option, yearly notes must be enabled in Periodic Notes plugin.")
+          .setName(msg.periodicNotes.displayPrevNextInYearlyNotes.name)
+          .setDesc(msg.periodicNotes.displayPrevNextInYearlyNotes.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.prevNextLinksEnabledInYearlyNotes)
@@ -1270,17 +1083,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Link display style")
-          .setDesc(
-            `
-              Specify the display style of links in the navigation header.
-              Full: < previous | parent | next >,
-              Full (double separator): < previous || parent || next >,
-              Separator: previous | parent | next,
-              Double separator: previous || parent || next,
-              None: previous parent next.
-            `,
-          )
+          .setName(msg.periodicNotes.linkDisplayStyle.name)
+          .setDesc(msg.periodicNotes.linkDisplayStyle.desc)
           .addDropdown((dropdown) => {
             dropdown
               .addOptions(threeWayDelimiterOptions)
@@ -1294,8 +1098,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       })
       .addSetting((setting) => {
         setting
-          .setName("Link prefix")
-          .setDesc("The string to display before each link (e.g., an emoji).")
+          .setName(msg.periodicNotes.linkPrefix.name)
+          .setDesc(msg.periodicNotes.linkPrefix.desc)
           .addText((text) => {
             text
               .setValue(this.plugin.settingsUnderChange.periodicNoteLinkPrefix)
@@ -1310,22 +1114,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(containerEl)
-      .setHeading("Pinned note content")
+      .setHeading(msg.pinnedContent.heading)
       .addSetting((setting) => {
         setting
-          .setName("Annotation strings")
-          .setDesc(
-            `
-              Display part of the current note in the navigation header.
-              The text shown starts immediately after the specified annotation string and
-              continues up to the end of the line.
-              If the start and end markers defined below appear immediately after
-              the annotation string, only the content between those markers is displayed instead.
-              Example: 📌[[note 1]]/[[note 2]](end of line) → 📌[[note 1]]/[[note 2]],
-              📌([[note 1]]/[[note 2]])[[note 3]] → 📌[[note 1]]/[[note 2]].
-              To specify multiple annotations, separate them with commas.
-            `,
-          )
+          .setName(msg.pinnedContent.annotationStrings.name)
+          .setDesc(msg.pinnedContent.annotationStrings.desc)
           .addText((text) => {
             const annotations =
               this.plugin.settingsUnderChange.annotationStringsForPinning.join(",");
@@ -1339,11 +1132,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                 );
                 this.plugin.triggerSettingsChangedDebounced();
               })
-              .setPlaceholder("📌,🔗");
+              .setPlaceholder(msg.pinnedContent.annotationStrings.placeholder);
           });
       })
       .addSetting((setting) => {
-        setting.setName("Start marker").addText((text) => {
+        setting.setName(msg.pinnedContent.startMarker.name).addText((text) => {
           text
             .setValue(this.plugin.settingsUnderChange.startMarkerForPinning)
             .onChange((value) => {
@@ -1353,11 +1146,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                 : value;
               this.plugin.triggerSettingsChangedDebounced();
             })
-            .setPlaceholder("(");
+            .setPlaceholder(msg.pinnedContent.startMarker.placeholder);
         });
       })
       .addSetting((setting) => {
-        setting.setName("End marker").addText((text) => {
+        setting.setName(msg.pinnedContent.endMarker.name).addText((text) => {
           text
             .setValue(this.plugin.settingsUnderChange.endMarkerForPinning)
             .onChange((value) => {
@@ -1367,13 +1160,13 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                 : value;
               this.plugin.triggerSettingsChangedDebounced();
             })
-            .setPlaceholder(")");
+            .setPlaceholder(msg.pinnedContent.endMarker.placeholder);
         });
       })
       .addSetting((setting) => {
         setting
-          .setName("Ignore code blocks")
-          .setDesc("If enabled, code blocks will be ignored when searching for pinned content.")
+          .setName(msg.pinnedContent.ignoreCodeBlocks.name)
+          .setDesc(msg.pinnedContent.ignoreCodeBlocks.desc)
           .addToggle((toggle) => {
             toggle
               .setValue(this.plugin.settingsUnderChange.ignoreCodeBlocksInPinning)
@@ -1385,31 +1178,23 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     const folderLinksSettingsArray = this.plugin.settingsUnderChange.folderLinksSettingsArray;
-    const folderLinksSettingGroup = new SettingGroup(containerEl).setHeading("Folder links");
+    const folderLinksSettingGroup = new SettingGroup(containerEl).setHeading(msg.folderLinks.heading);
     for (let i = 0; i < folderLinksSettingsArray.length; i++) {
       const folderLinkSettings = folderLinksSettingsArray[i];
 
       folderLinksSettingGroup
         .addSetting((setting) => {
           // The actual index will be the number shown here - 1.
-          setting.setName(`Folder setting #${i + 1}`).setHeading();
+          setting.setName(msg.folderLinks.folderSettingHeading(i + 1)).setHeading();
         })
         .addSetting((setting) => {
           setting
-            .setName("Folder paths")
-            .setDesc(
-              `
-                For each folder specified here, files in the same folder as the currently opened
-                file will be shown in the navigation header. Multiple folders can be specified
-                (enter one path per line). Glob patterns are supported
-                (e.g., **: all folders; *: all folders directly under root;
-                folder/*: all folders directly under "folder").
-              `,
-            )
+            .setName(msg.folderLinks.folderPaths.name)
+            .setDesc(msg.folderLinks.folderPaths.desc)
             .addTextArea((text) => {
               text
                 .setValue(folderLinkSettings.folderPaths.join("\n"))
-                .setPlaceholder("path/to/the/folder\nanother/folder/*")
+                .setPlaceholder(msg.folderLinks.folderPaths.placeholder)
                 .onChange((value) => {
                   folderLinkSettings.folderPaths = parseMultiLineInput(value, true);
                   this.plugin.triggerSettingsChangedDebounced();
@@ -1418,17 +1203,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Excluded folder paths")
-            .setDesc(
-              `
-                Specify the folder paths to exclude. Multiple folders can be specified
-                (enter one path per line). Glob patterns are supported.
-              `,
-            )
+            .setName(msg.folderLinks.excludedFolderPaths.name)
+            .setDesc(msg.folderLinks.excludedFolderPaths.desc)
             .addTextArea((text) => {
               text
                 .setValue(folderLinkSettings.excludedFolderPaths.join("\n"))
-                .setPlaceholder("path/to/the/folder\nanother/folder/*")
+                .setPlaceholder(msg.folderLinks.excludedFolderPaths.placeholder)
                 .onChange((value) => {
                   folderLinkSettings.excludedFolderPaths = parseMultiLineInput(value, true);
                   this.plugin.triggerSettingsChangedDebounced();
@@ -1437,8 +1217,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Recursive")
-            .setDesc("Whether to include files in subfolders.")
+            .setName(msg.folderLinks.recursive.name)
+            .setDesc(msg.folderLinks.recursive.desc)
             .addToggle((toggle) => {
               toggle.setValue(folderLinkSettings.recursive).onChange((value) => {
                 folderLinkSettings.recursive = value;
@@ -1448,17 +1228,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Include patterns")
-            .setDesc(
-              `
-                Include files that match these patterns partially. Enter one per line.
-                Leave empty for all files.
-              `,
-            )
+            .setName(msg.folderLinks.includePatterns.name)
+            .setDesc(msg.folderLinks.includePatterns.desc)
             .addTextArea((text) => {
               text
                 .setValue(folderLinkSettings.includePatterns.join("\n"))
-                .setPlaceholder("Chapter\n.pdf")
+                .setPlaceholder(msg.folderLinks.includePatterns.placeholder)
                 .onChange((value) => {
                   folderLinkSettings.includePatterns = parseMultiLineInput(
                     value,
@@ -1470,12 +1245,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Exclude patterns")
-            .setDesc("Exclude files that match these patterns partially. Enter one per line.")
+            .setName(msg.folderLinks.excludePatterns.name)
+            .setDesc(msg.folderLinks.excludePatterns.desc)
             .addTextArea((text) => {
               text
                 .setValue(folderLinkSettings.excludePatterns.join("\n"))
-                .setPlaceholder(".canvas")
+                .setPlaceholder(msg.folderLinks.excludePatterns.placeholder)
                 .onChange((value) => {
                   folderLinkSettings.excludePatterns = parseMultiLineInput(
                     value,
@@ -1487,8 +1262,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Enable regular expressions")
-            .setDesc("Whether to enable regular expressions for include/exclude patterns.")
+            .setName(msg.folderLinks.enableRegex.name)
+            .setDesc(msg.folderLinks.enableRegex.desc)
             .addToggle((toggle) => {
               toggle.setValue(folderLinkSettings.enableRegex).onChange((value) => {
                 folderLinkSettings.enableRegex = value;
@@ -1498,15 +1273,13 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Filter by")
-            .setDesc(
-              "Specify whether to use file names or property values for include/exclude patterns.",
-            )
+            .setName(msg.folderLinks.filterBy.name)
+            .setDesc(msg.folderLinks.filterBy.desc)
             .addDropdown((dropdown) => {
               dropdown
                 .addOptions({
-                  filename: "File name",
-                  property: "Property",
+                  filename: msg.folderLinks.filterBy.options.filename,
+                  property: msg.folderLinks.filterBy.options.property,
                 })
                 .setValue(folderLinkSettings.filterBy)
                 .onChange((value) => {
@@ -1517,13 +1290,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Property name to filter by")
-            .setDesc(
-              `
-                The name of the property to filter by.
-                This is required when "Filter by" is set to "Property".
-              `,
-            )
+            .setName(msg.folderLinks.propertyNameToFilterBy.name)
+            .setDesc(msg.folderLinks.propertyNameToFilterBy.desc)
             .addText((text) => {
               text.setValue(folderLinkSettings.filterPropertyName).onChange((value) => {
                 folderLinkSettings.filterPropertyName = value.trim();
@@ -1532,11 +1300,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
             });
         })
         .addSetting((setting) => {
-          setting.setName("Sort order").addDropdown((dropdown) => {
+          setting.setName(msg.folderLinks.sortOrder.name).addDropdown((dropdown) => {
             dropdown
               .addOptions({
-                asc: "Ascending",
-                desc: "Descending",
+                asc: msg.folderLinks.sortOrder.options.asc,
+                desc: msg.folderLinks.sortOrder.options.desc,
               })
               .setValue(folderLinkSettings.sortOrder)
               .onChange((value) => {
@@ -1546,13 +1314,13 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
         })
         .addSetting((setting) => {
-          setting.setName("Sort by").addDropdown((dropdown) => {
+          setting.setName(msg.folderLinks.sortBy.name).addDropdown((dropdown) => {
             dropdown
               .addOptions({
-                filename: "File name",
-                created: "Creation date",
-                modified: "Modification date",
-                property: "Property",
+                filename: msg.folderLinks.sortBy.options.filename,
+                created: msg.folderLinks.sortBy.options.created,
+                modified: msg.folderLinks.sortBy.options.modified,
+                property: msg.folderLinks.sortBy.options.property,
               })
               .setValue(folderLinkSettings.sortBy)
               .onChange((value) => {
@@ -1567,13 +1335,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Property name to sort by")
-            .setDesc(
-              `
-                The name of the property to sort by.
-                This is required when "Sort by" is set to "Property".
-              `,
-            )
+            .setName(msg.folderLinks.propertyNameToSortBy.name)
+            .setDesc(msg.folderLinks.propertyNameToSortBy.desc)
             .addText((text) => {
               text.setValue(folderLinkSettings.sortPropertyName).onChange((value) => {
                 folderLinkSettings.sortPropertyName = value.trim();
@@ -1583,14 +1346,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Max links")
-            .setDesc(
-              `
-                The maximum number of folder links to display.
-                For example, if set to 3, the display would look like
-                <prev3 prev2 prev1 | parent | next1 next2 next3>.
-              `,
-            )
+            .setName(msg.folderLinks.maxLinks.name)
+            .setDesc(msg.folderLinks.maxLinks.desc)
             .addText((text) => {
               text.inputEl.type = "number";
               text.setValue(String(folderLinkSettings.maxLinks)).onChange((value) => {
@@ -1604,10 +1361,10 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
             });
         })
         .addSetting((setting) => {
-          setting.setName("Path to the parent note").addText((text) => {
+          setting.setName(msg.folderLinks.pathToParentNote.name).addText((text) => {
             text
               .setValue(folderLinkSettings.parentPath)
-              .setPlaceholder("path/to/the/note.md")
+              .setPlaceholder(msg.folderLinks.pathToParentNote.placeholder)
               .onChange((value) => {
                 const trimmed = value.trim();
                 folderLinkSettings.parentPath = trimmed === "" ? "" : normalizePath(trimmed);
@@ -1617,17 +1374,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Link display style")
-            .setDesc(
-              `
-                Specify the display style of prev/next/parent links in the navigation header.
-                Full: < previous | parent | next >,
-                Full (double separator): < previous || parent || next >,
-                Separator: previous | parent | next,
-                Double separator: previous || parent || next,
-                None: previous parent next.
-              `,
-            )
+            .setName(msg.folderLinks.linkDisplayStyle.name)
+            .setDesc(msg.folderLinks.linkDisplayStyle.desc)
             .addDropdown((dropdown) => {
               dropdown
                 .addOptions(threeWayDelimiterOptions)
@@ -1640,8 +1388,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
         })
         .addSetting((setting) => {
           setting
-            .setName("Link prefix")
-            .setDesc("The string to display before each link (e.g., an emoji).")
+            .setName(msg.folderLinks.linkPrefix.name)
+            .setDesc(msg.folderLinks.linkPrefix.desc)
             .addText((text) => {
               text.setValue(folderLinkSettings.linkPrefix).onChange((value) => {
                 folderLinkSettings.linkPrefix = this.plugin.settings.trimStringsInSettings
@@ -1655,14 +1403,14 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           setting
             .setName("")
             .addButton((button) => {
-              button.setButtonText("Move up").onClick(() => {
+              button.setButtonText(msg.folderLinks.controls.moveUp).onClick(() => {
                 this.swapFolderLinksSettings(i, i - 1);
                 this.plugin.triggerSettingsChangedDebounced();
                 this.display(); // Force re-render.
               });
             })
             .addButton((button) => {
-              button.setButtonText("Move down").onClick(() => {
+              button.setButtonText(msg.folderLinks.controls.moveDown).onClick(() => {
                 this.swapFolderLinksSettings(i, i + 1);
                 this.plugin.triggerSettingsChangedDebounced();
                 this.display(); // Force re-render.
@@ -1670,7 +1418,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
             })
             .addButton((button) => {
               button
-                .setButtonText("Remove")
+                .setButtonText(msg.folderLinks.controls.remove)
                 .setWarning()
                 .onClick(() => {
                   folderLinksSettingsArray.splice(i, 1);
@@ -1683,7 +1431,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
     folderLinksSettingGroup.addSetting((setting) => {
       setting.setName("").addButton((button) => {
         button
-          .setButtonText("Add folder setting")
+          .setButtonText(msg.folderLinks.controls.addFolderSetting)
           .setCta()
           .onClick(() => {
             this.plugin.settingsUnderChange.folderLinksSettingsArray.push(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,12 @@
-import { normalizePath, PluginSettingTab, SettingGroup } from "obsidian";
+import {
+  Modal,
+  normalizePath,
+  PluginSettingTab,
+  Setting,
+  SettingGroup,
+  setIcon,
+  setTooltip,
+} from "obsidian";
 import type { IGranularity } from "obsidian-daily-notes-interface";
 import { lt } from "semver";
 import type NavLinkHeader from "./main";
@@ -67,6 +75,7 @@ export interface NavLinkHeaderSettings {
 }
 
 export interface FolderLinksSettings {
+  ruleName: string;
   folderPaths: string[];
   excludedFolderPaths: string[];
   recursive: boolean;
@@ -139,6 +148,7 @@ export const DEFAULT_SETTINGS: NavLinkHeaderSettings = {
 };
 
 const DEFAULT_FOLDER_LINKS_SETTINGS: FolderLinksSettings = {
+  ruleName: "",
   folderPaths: [],
   excludedFolderPaths: [],
   recursive: false,
@@ -397,6 +407,9 @@ function convertOldSettings(loadedData: Record<string, unknown>): Record<string,
  * Represents the settings tab for the Nav Link Header plugin in Obsidian.
  */
 export class NavLinkHeaderSettingTab extends PluginSettingTab {
+  private activeTabId: string = "common";
+  private collapsedFolderLinkSettings = new WeakSet<FolderLinksSettings>();
+
   constructor(private plugin: NavLinkHeader) {
     super(plugin.app, plugin);
   }
@@ -410,7 +423,120 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
     const threeWayDelimiterOptions =
       msg.threeWayDelimiterOptions satisfies Record<ThreeWayDelimiters, string>;
 
-    new SettingGroup(containerEl)
+    const tabsEl = containerEl.createDiv();
+    tabsEl.style.display = "flex";
+    tabsEl.style.flexWrap = "wrap";
+    tabsEl.style.gap = "8px";
+    tabsEl.style.marginBottom = "12px";
+
+    const panelsEl = containerEl.createDiv();
+
+    const tabButtons = new Map<string, HTMLButtonElement>();
+    const tabPanels = new Map<string, HTMLDivElement>();
+
+    const createPanel = (id: string, label: string): HTMLDivElement => {
+      const button = tabsEl.createEl("button", { text: label, cls: "mod-muted" });
+      button.setAttr("type", "button");
+      button.style.cursor = "pointer";
+
+      const panel = panelsEl.createDiv();
+      panel.style.display = "none";
+
+      button.addEventListener("click", () => {
+        this.activeTabId = id;
+        for (const [tabId, tabButton] of tabButtons.entries()) {
+          const isActive = tabId === id;
+          tabButton.classList.toggle("mod-cta", isActive);
+          tabButton.classList.toggle("mod-muted", !isActive);
+          tabButton.setAttr("aria-pressed", String(isActive));
+        }
+        for (const [tabId, tabPanel] of tabPanels.entries()) {
+          tabPanel.style.display = tabId === id ? "block" : "none";
+        }
+      });
+
+      tabButtons.set(id, button);
+      tabPanels.set(id, panel);
+      return panel;
+    };
+
+    const commonPanel = createPanel("common", msg.tabs.common);
+    const enabledViewsPanel = createPanel("enabledViews", msg.tabs.enabledViews);
+    const annotatedLinksPanel = createPanel("annotatedLinks", msg.tabs.annotatedLinks);
+    const pinnedContentPanel = createPanel("pinnedContent", msg.tabs.pinnedContent);
+    const propertyLinksPanel = createPanel("propertyLinks", msg.tabs.propertyLinks);
+    const periodicNotesPanel = createPanel("periodicNotes", msg.tabs.periodicNotes);
+    const folderLinksPanel = createPanel("folderLinks", msg.tabs.folderLinks);
+
+    const initialTabId = tabButtons.has(this.activeTabId) ? this.activeTabId : "common";
+    tabButtons.get(initialTabId)?.click();
+
+    new SettingGroup(commonPanel)
+      .addSetting((setting) => {
+        setting
+          .setName(msg.general.pluginGuide.name)
+          .setDesc(msg.general.pluginGuide.desc)
+          .addButton((button) => {
+            button.setButtonText(msg.general.pluginGuide.linkLabel).onClick(() => {
+              window.open("https://github.com/ahts4962/nav-link-header", "_blank");
+            });
+          });
+      })
+      .addSetting((setting) => {
+        const affectedSettings = msg.general.trimWhitespaceInInputFields.affectedSettings
+          .map((s) => `"${s}"`)
+          .join(", ");
+
+        setting
+          .setName(msg.general.trimWhitespaceInInputFields.name)
+          .setDesc(msg.general.trimWhitespaceInInputFields.desc)
+          .addToggle((toggle) => {
+            toggle
+              .setValue(this.plugin.settingsUnderChange.trimStringsInSettings)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.trimStringsInSettings = value;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+
+        this.addTooltipToDescription(
+          setting,
+          msg.general.trimWhitespaceInInputFields.descTooltip.replace(
+            "{affectedSettings}",
+            affectedSettings,
+          ),
+        );
+      })
+      .addSetting((setting) => {
+        setting
+          .setName(msg.general.displayLoadingMessage.name)
+          .setDesc(msg.general.displayLoadingMessage.desc)
+          .addToggle((toggle) => {
+            toggle
+              .setValue(this.plugin.settingsUnderChange.displayLoadingMessage)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.displayLoadingMessage = value;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+      })
+      .addSetting((setting) => {
+        setting
+          .setName(msg.general.displayPlaceholder.name)
+          .setDesc(msg.general.displayPlaceholder.desc)
+          .addToggle((toggle) => {
+            toggle
+              .setValue(this.plugin.settingsUnderChange.displayPlaceholder)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.displayPlaceholder = value;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+      })
+      ;
+
+    new SettingGroup(commonPanel)
+      .setHeading(msg.sections.display)
       .addSetting((setting) => {
         setting
           .setName(msg.general.matchNavigationWidthToLineLength.name)
@@ -444,6 +570,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
           });
+
+        this.addTooltipToDescription(
+          setting,
+          msg.general.displayOrderOfLinks.descTooltip
+            .replaceAll("{periodic}", DISPLAY_ORDER_PLACEHOLDER_PERIODIC)
+            .replaceAll("{property}", DISPLAY_ORDER_PLACEHOLDER_PROPERTY)
+            .replaceAll("{folder}", DISPLAY_ORDER_PLACEHOLDER_FOLDER),
+        );
+        this.addTipToDescription(setting, msg.general.displayOrderOfLinks.tip);
       })
       .addSetting((setting) => {
         setting
@@ -504,6 +639,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
           });
+
+        this.addTipToDescription(setting, msg.general.itemCollapsePrefixes.tip);
       })
       .addSetting((setting) => {
         setting
@@ -520,71 +657,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
           });
-      })
-      .addSetting((setting) => {
-        setting
-          .setName(msg.general.displayLoadingMessage.name)
-          .setDesc(msg.general.displayLoadingMessage.desc)
-          .addToggle((toggle) => {
-            toggle
-              .setValue(this.plugin.settingsUnderChange.displayLoadingMessage)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.displayLoadingMessage = value;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
-      })
-      .addSetting((setting) => {
-        setting
-          .setName(msg.general.displayPlaceholder.name)
-          .setDesc(msg.general.displayPlaceholder.desc)
-          .addToggle((toggle) => {
-            toggle
-              .setValue(this.plugin.settingsUnderChange.displayPlaceholder)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.displayPlaceholder = value;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
-      })
-      .addSetting((setting) => {
-        setting
-          .setName(msg.general.confirmFileCreation.name)
-          .setDesc(msg.general.confirmFileCreation.desc)
-          .addToggle((toggle) => {
-            toggle
-              .setValue(this.plugin.settingsUnderChange.confirmFileCreation)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.confirmFileCreation = value;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
-      })
-      .addSetting((setting) => {
-        const affectedSettings = msg.general.trimWhitespaceInInputFields.affectedSettings
-          .map((s) => `"${s}"`)
-          .join(", ");
 
-        setting
-          .setName(msg.general.trimWhitespaceInInputFields.name)
-          .setDesc(
-            msg.general.trimWhitespaceInInputFields.desc.replace(
-              "{affectedSettings}",
-              affectedSettings,
-            ),
-          )
-          .addToggle((toggle) => {
-            toggle
-              .setValue(this.plugin.settingsUnderChange.trimStringsInSettings)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.trimStringsInSettings = value;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
+        this.addTipToDescription(setting, msg.general.mergePrefixes.tip);
       });
 
-    new SettingGroup(containerEl)
-      .setHeading(msg.displayTargets.heading)
+    new SettingGroup(enabledViewsPanel)
+      .setHeading(msg.sections.displayPosition)
       .addSetting((setting) => {
         setting
           .setName(msg.displayTargets.inPanes.name)
@@ -595,6 +673,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
           });
+
+        this.addTipToDescription(setting, msg.displayTargets.inPanes.tip);
       })
       .addSetting((setting) => {
         setting
@@ -608,7 +688,12 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                 this.plugin.triggerSettingsChangedDebounced();
               });
           });
-      })
+
+        this.addTipToDescription(setting, msg.displayTargets.inPagePreviews.tip);
+      });
+
+    new SettingGroup(enabledViewsPanel)
+      .setHeading(msg.sections.enabledViews)
       .addSetting((setting) => {
         setting
           .setName(msg.displayTargets.inMarkdownViews.name)
@@ -712,8 +797,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       });
 
-    new SettingGroup(containerEl)
-      .setHeading(msg.annotatedLinks.heading)
+    new SettingGroup(annotatedLinksPanel)
       .addSetting((setting) => {
         setting
           .setName(msg.annotatedLinks.annotationStringsForBacklinks.name)
@@ -735,6 +819,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
           });
+
+        this.addTooltipToDescription(
+          setting,
+          msg.annotatedLinks.annotationStringsForBacklinksTooltip.replaceAll(
+            "{emojiPlaceholder}",
+            EMOJI_ANNOTATION_PLACEHOLDER,
+          ),
+        );
+        this.addTipToDescription(setting, msg.annotatedLinks.annotationStringsForBacklinks.tip);
       })
       .addSetting((setting) => {
         setting
@@ -804,6 +897,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
           });
+
+        this.addTipToDescription(setting, msg.annotatedLinks.advancedAnnotationStringsForCurrentNote.tip);
       })
       .addSetting((setting) => {
         setting
@@ -813,7 +908,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
             toggle
               .setValue(this.plugin.settingsUnderChange.allowSpaceAfterAnnotationString)
               .onChange((value) => {
-                this.plugin.settingsUnderChange.allowSpaceAfterAnnotationString = value;
+              this.plugin.settingsUnderChange.allowSpaceAfterAnnotationString = value;
                 this.plugin.triggerSettingsChangedDebounced();
               });
           });
@@ -832,8 +927,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       });
 
-    new SettingGroup(containerEl)
-      .setHeading(msg.propertyLinks.heading)
+    new SettingGroup(propertyLinksPanel)
       .addSetting((setting) => {
         setting
           .setName(msg.propertyLinks.propertyMappings.name)
@@ -853,6 +947,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                 this.plugin.triggerSettingsChangedDebounced();
               });
           });
+
+        this.addTipToDescription(setting, msg.propertyLinks.propertyMappings.tip);
       })
       .addSetting((setting) => {
         setting
@@ -868,9 +964,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               .onChange((value) => {
                 this.plugin.settingsUnderChange.previousLinkPropertyMappings =
                   parsePropertyMappings(value, this.plugin.settings.trimStringsInSettings);
-                this.plugin.triggerSettingsChangedDebounced();
-              });
+              this.plugin.triggerSettingsChangedDebounced();
+            });
           });
+
+        this.addTipToDescription(setting, msg.propertyLinks.previousNotePropertyMappings.tip);
       })
       .addSetting((setting) => {
         setting
@@ -888,9 +986,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                   value,
                   this.plugin.settings.trimStringsInSettings,
                 );
-                this.plugin.triggerSettingsChangedDebounced();
-              });
+              this.plugin.triggerSettingsChangedDebounced();
+            });
           });
+
+        this.addTipToDescription(setting, msg.propertyLinks.nextNotePropertyMappings.tip);
       })
       .addSetting((setting) => {
         setting
@@ -908,9 +1008,11 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
                   value,
                   this.plugin.settings.trimStringsInSettings,
                 );
-                this.plugin.triggerSettingsChangedDebounced();
-              });
+              this.plugin.triggerSettingsChangedDebounced();
+            });
           });
+
+        this.addTipToDescription(setting, msg.propertyLinks.parentNotePropertyMappings.tip);
       })
       .addSetting((setting) => {
         setting
@@ -946,8 +1048,8 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       });
 
-    new SettingGroup(containerEl)
-      .setHeading(msg.periodicNotes.heading)
+    new SettingGroup(periodicNotesPanel)
+      .setHeading(msg.periodicNotes.sections.daily)
       .addSetting((setting) => {
         setting
           .setName(msg.periodicNotes.displayPrevNextInDailyNotes.name)
@@ -978,7 +1080,10 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
         });
-      })
+      });
+
+    new SettingGroup(periodicNotesPanel)
+      .setHeading(msg.periodicNotes.sections.weekly)
       .addSetting((setting) => {
         setting
           .setName(msg.periodicNotes.displayPrevNextInWeeklyNotes.name)
@@ -1008,7 +1113,10 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
         });
-      })
+      });
+
+    new SettingGroup(periodicNotesPanel)
+      .setHeading(msg.periodicNotes.sections.monthly)
       .addSetting((setting) => {
         setting
           .setName(msg.periodicNotes.displayPrevNextInMonthlyNotes.name)
@@ -1037,7 +1145,10 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               this.plugin.triggerSettingsChangedDebounced();
             });
         });
-      })
+      });
+
+    new SettingGroup(periodicNotesPanel)
+      .setHeading(msg.periodicNotes.sections.quarterly)
       .addSetting((setting) => {
         setting
           .setName(msg.periodicNotes.displayPrevNextInQuarterlyNotes.name)
@@ -1058,16 +1169,17 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               none: msg.periodicNotes.granularityOptions.none,
               year: msg.periodicNotes.granularityOptions.year,
             })
-            .setValue(
-              this.plugin.settingsUnderChange.parentLinkGranularityInQuarterlyNotes ?? "none",
-            )
+            .setValue(this.plugin.settingsUnderChange.parentLinkGranularityInQuarterlyNotes ?? "none")
             .onChange((value) => {
               this.plugin.settingsUnderChange.parentLinkGranularityInQuarterlyNotes =
                 value !== "none" ? (value as IGranularity) : "none";
               this.plugin.triggerSettingsChangedDebounced();
             });
         });
-      })
+      });
+
+    new SettingGroup(periodicNotesPanel)
+      .setHeading(msg.periodicNotes.sections.yearly)
       .addSetting((setting) => {
         setting
           .setName(msg.periodicNotes.displayPrevNextInYearlyNotes.name)
@@ -1077,6 +1189,19 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               .setValue(this.plugin.settingsUnderChange.prevNextLinksEnabledInYearlyNotes)
               .onChange((value) => {
                 this.plugin.settingsUnderChange.prevNextLinksEnabledInYearlyNotes = value;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+      })
+      .addSetting((setting) => {
+        setting
+          .setName(msg.general.confirmFileCreation.name)
+          .setDesc(msg.general.confirmFileCreation.desc)
+          .addToggle((toggle) => {
+            toggle
+              .setValue(this.plugin.settingsUnderChange.confirmFileCreation)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.confirmFileCreation = value;
                 this.plugin.triggerSettingsChangedDebounced();
               });
           });
@@ -1113,8 +1238,7 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
           });
       });
 
-    new SettingGroup(containerEl)
-      .setHeading(msg.pinnedContent.heading)
+    new SettingGroup(pinnedContentPanel)
       .addSetting((setting) => {
         setting
           .setName(msg.pinnedContent.annotationStrings.name)
@@ -1127,13 +1251,15 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               .onChange((value) => {
                 this.plugin.settingsUnderChange.annotationStringsForPinning = parsePrefixStrings(
                   value,
-                  this.plugin.settings.trimStringsInSettings,
-                  false,
-                );
-                this.plugin.triggerSettingsChangedDebounced();
-              })
-              .setPlaceholder(msg.pinnedContent.annotationStrings.placeholder);
+                this.plugin.settings.trimStringsInSettings,
+                false,
+              );
+              this.plugin.triggerSettingsChangedDebounced();
+            })
+            .setPlaceholder(msg.pinnedContent.annotationStrings.placeholder);
           });
+
+        this.addTipToDescription(setting, msg.pinnedContent.annotationStrings.tip);
       })
       .addSetting((setting) => {
         setting.setName(msg.pinnedContent.startMarker.name).addText((text) => {
@@ -1178,15 +1304,124 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     const folderLinksSettingsArray = this.plugin.settingsUnderChange.folderLinksSettingsArray;
-    const folderLinksSettingGroup = new SettingGroup(containerEl).setHeading(msg.folderLinks.heading);
+
+    const addFolderSettingRow = folderLinksPanel.createDiv();
+    addFolderSettingRow.style.display = "flex";
+    addFolderSettingRow.style.justifyContent = "flex-end";
+    addFolderSettingRow.style.marginBottom = "10px";
+
+    const addFolderSettingButton = addFolderSettingRow.createEl("button", {
+      text: msg.folderLinks.controls.addFolderSetting,
+      cls: "mod-cta",
+    });
+    addFolderSettingButton.setAttr("type", "button");
+    addFolderSettingButton.addEventListener("click", () => {
+      this.plugin.settingsUnderChange.folderLinksSettingsArray.push(
+        deepCopy(DEFAULT_FOLDER_LINKS_SETTINGS),
+      );
+      this.plugin.triggerSettingsChangedDebounced();
+      this.display();
+    });
+
     for (let i = 0; i < folderLinksSettingsArray.length; i++) {
       const folderLinkSettings = folderLinksSettingsArray[i];
+      const ruleDisplayName =
+        folderLinkSettings.ruleName.trim() || msg.folderLinks.folderSettingHeading(i + 1);
+
+      const isCollapsed = this.collapsedFolderLinkSettings.has(folderLinkSettings);
+
+      const folderLinksSettingGroup = new SettingGroup(folderLinksPanel);
 
       folderLinksSettingGroup
         .addSetting((setting) => {
-          // The actual index will be the number shown here - 1.
-          setting.setName(msg.folderLinks.folderSettingHeading(i + 1)).setHeading();
-        })
+          setting
+            .setName("")
+            .addButton((button) => {
+              button.buttonEl.style.marginLeft = "auto";
+              button.setButtonText(msg.folderLinks.controls.pinToTop).onClick(() => {
+                this.swapFolderLinksSettings(i, 0);
+                this.plugin.triggerSettingsChangedDebounced();
+                this.display();
+              });
+            })
+            .addButton((button) => {
+              button.setButtonText(msg.folderLinks.controls.moveUp).onClick(() => {
+                this.swapFolderLinksSettings(i, i - 1);
+                this.plugin.triggerSettingsChangedDebounced();
+                this.display();
+              });
+            })
+            .addButton((button) => {
+              button.setButtonText(msg.folderLinks.controls.moveDown).onClick(() => {
+                this.swapFolderLinksSettings(i, i + 1);
+                this.plugin.triggerSettingsChangedDebounced();
+                this.display();
+              });
+            })
+            .addButton((button) => {
+              button
+                .setButtonText(msg.folderLinks.controls.remove)
+                .setWarning()
+                .onClick(() => {
+                  folderLinksSettingsArray.splice(i, 1);
+                  this.plugin.triggerSettingsChangedDebounced();
+                  this.display();
+                });
+            });
+
+          const nameEl = setting.nameEl;
+          nameEl.empty();
+          nameEl.style.display = "flex";
+          nameEl.style.alignItems = "center";
+          nameEl.style.gap = "6px";
+
+          const collapseToggleEl = nameEl.createEl("button", {
+            cls: "clickable-icon",
+          });
+          collapseToggleEl.setAttr("type", "button");
+          collapseToggleEl.style.padding = "0";
+          collapseToggleEl.style.minWidth = "16px";
+          collapseToggleEl.style.minHeight = "16px";
+          collapseToggleEl.style.border = "none";
+          collapseToggleEl.style.background = "transparent";
+          collapseToggleEl.style.display = "inline-flex";
+          collapseToggleEl.style.alignItems = "center";
+          collapseToggleEl.style.justifyContent = "center";
+          collapseToggleEl.style.transform = isCollapsed ? "rotate(-90deg)" : "rotate(0deg)";
+          collapseToggleEl.style.transition = "transform 0.2s ease-in-out";
+          setIcon(collapseToggleEl, "chevron-down");
+          collapseToggleEl.addEventListener("click", () => {
+            if (this.collapsedFolderLinkSettings.has(folderLinkSettings)) {
+              this.collapsedFolderLinkSettings.delete(folderLinkSettings);
+            } else {
+              this.collapsedFolderLinkSettings.add(folderLinkSettings);
+            }
+            this.display();
+          });
+
+          const ruleNameEl = nameEl.createEl("span", { text: ruleDisplayName });
+          ruleNameEl.style.cursor = "pointer";
+          ruleNameEl.style.fontWeight = "var(--font-medium)";
+          ruleNameEl.style.userSelect = "none";
+          ruleNameEl.addEventListener("click", () => {
+            new FolderRuleNameModal(
+              this.plugin,
+              msg.folderLinks.controls.rename,
+              ruleDisplayName,
+              (renamed) => {
+                folderLinkSettings.ruleName = renamed.trim();
+                this.plugin.triggerSettingsChangedDebounced();
+                this.display();
+              },
+            ).open();
+          });
+        });
+
+      if (isCollapsed) {
+        continue;
+      }
+
+      folderLinksSettingGroup
         .addSetting((setting) => {
           setting
             .setName(msg.folderLinks.folderPaths.name)
@@ -1399,49 +1634,56 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               });
             });
         })
-        .addSetting((setting) => {
-          setting
-            .setName("")
-            .addButton((button) => {
-              button.setButtonText(msg.folderLinks.controls.moveUp).onClick(() => {
-                this.swapFolderLinksSettings(i, i - 1);
-                this.plugin.triggerSettingsChangedDebounced();
-                this.display(); // Force re-render.
-              });
-            })
-            .addButton((button) => {
-              button.setButtonText(msg.folderLinks.controls.moveDown).onClick(() => {
-                this.swapFolderLinksSettings(i, i + 1);
-                this.plugin.triggerSettingsChangedDebounced();
-                this.display(); // Force re-render.
-              });
-            })
-            .addButton((button) => {
-              button
-                .setButtonText(msg.folderLinks.controls.remove)
-                .setWarning()
-                .onClick(() => {
-                  folderLinksSettingsArray.splice(i, 1);
-                  this.plugin.triggerSettingsChangedDebounced();
-                  this.display(); // Force re-render.
-                });
-            });
-        });
+        ;
     }
-    folderLinksSettingGroup.addSetting((setting) => {
-      setting.setName("").addButton((button) => {
-        button
-          .setButtonText(msg.folderLinks.controls.addFolderSetting)
-          .setCta()
-          .onClick(() => {
-            this.plugin.settingsUnderChange.folderLinksSettingsArray.push(
-              deepCopy(DEFAULT_FOLDER_LINKS_SETTINGS),
-            );
-            this.plugin.triggerSettingsChangedDebounced();
-            this.display(); // Force re-render.
-          });
-      });
-    });
+
+    this.applyDescriptionLineBreaks(containerEl);
+  }
+
+  private applyDescriptionLineBreaks(root: HTMLElement): void {
+    const descriptionElements = root.querySelectorAll<HTMLElement>(".setting-item-description");
+
+    for (const descEl of descriptionElements) {
+      descEl.style.whiteSpace = "pre-line";
+      descEl.style.lineHeight = "1.45";
+      descEl.style.marginTop = "4px";
+    }
+  }
+
+  private addTipToDescription(setting: { descEl: HTMLElement }, tipText: string): void {
+    const content = tipText.trim();
+    if (content.length === 0) {
+      return;
+    }
+
+    const tipEl = document.createElement("span");
+    tipEl.className = "nav-link-header-tip-text header-tip-etxt";
+    tipEl.textContent = content;
+    setting.descEl.appendChild(document.createElement("br"));
+    setting.descEl.appendChild(tipEl);
+  }
+
+  private addTooltipToDescription(setting: { descEl: HTMLElement }, tooltipText: string): void {
+    const content = tooltipText.trim();
+    if (content.length === 0) {
+      return;
+    }
+
+    const icon = document.createElement("span");
+    icon.style.display = "inline-flex";
+    icon.style.verticalAlign = "text-bottom";
+    icon.style.marginLeft = "4px";
+    icon.style.cursor = "help";
+    icon.style.width = "16px";
+    icon.style.height = "16px";
+    setIcon(icon, "info");
+    const svgEl = icon.querySelector("svg");
+    if (svgEl instanceof SVGElement) {
+      svgEl.style.width = "16px";
+      svgEl.style.height = "16px";
+    }
+    setTooltip(icon, content);
+    setting.descEl.appendChild(icon);
   }
 
   /**
@@ -1461,6 +1703,51 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
     const temp = folderLinksSettingsArray[index1];
     folderLinksSettingsArray[index1] = folderLinksSettingsArray[index2];
     folderLinksSettingsArray[index2] = temp;
+  }
+}
+
+class FolderRuleNameModal extends Modal {
+  private value: string;
+
+  constructor(
+    private plugin: NavLinkHeader,
+    private title: string,
+    initialValue: string,
+    private onSubmit: (value: string) => void,
+  ) {
+    super(plugin.app);
+    this.value = initialValue;
+  }
+
+  public onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl("h2", { text: this.title });
+    new Setting(contentEl).addText((text) => {
+      text.setValue(this.value).onChange((value) => {
+        this.value = value;
+      });
+      text.inputEl.focus();
+      text.inputEl.select();
+    });
+
+    new Setting(contentEl)
+      .addButton((button) => {
+        button.setButtonText("保存").setCta().onClick(() => {
+          this.onSubmit(this.value);
+          this.close();
+        });
+      })
+      .addButton((button) => {
+        button.setButtonText("取消").onClick(() => {
+          this.close();
+        });
+      });
+  }
+
+  public onClose(): void {
+    this.contentEl.empty();
   }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -662,7 +662,6 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(enabledViewsPanel)
-      .setHeading(msg.sections.displayPosition)
       .addSetting((setting) => {
         setting
           .setName(msg.displayTargets.inPanes.name)
@@ -1049,6 +1048,52 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
       });
 
     new SettingGroup(periodicNotesPanel)
+      .addSetting((setting) => {
+        setting
+          .setName(msg.general.confirmFileCreation.name)
+          .setDesc(msg.general.confirmFileCreation.desc)
+          .addToggle((toggle) => {
+            toggle
+              .setValue(this.plugin.settingsUnderChange.confirmFileCreation)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.confirmFileCreation = value;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+      })
+      .addSetting((setting) => {
+        setting
+          .setName(msg.periodicNotes.linkDisplayStyle.name)
+          .setDesc(msg.periodicNotes.linkDisplayStyle.desc)
+          .addDropdown((dropdown) => {
+            dropdown
+              .addOptions(threeWayDelimiterOptions)
+              .setValue(this.plugin.settingsUnderChange.periodicNoteLinkDisplayStyle)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.periodicNoteLinkDisplayStyle =
+                  value as ThreeWayDelimiters;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+      })
+      .addSetting((setting) => {
+        setting
+          .setName(msg.periodicNotes.linkPrefix.name)
+          .setDesc(msg.periodicNotes.linkPrefix.desc)
+          .addText((text) => {
+            text
+              .setValue(this.plugin.settingsUnderChange.periodicNoteLinkPrefix)
+              .onChange((value) => {
+                this.plugin.settingsUnderChange.periodicNoteLinkPrefix = this.plugin.settings
+                  .trimStringsInSettings
+                  ? value.trim()
+                  : value;
+                this.plugin.triggerSettingsChangedDebounced();
+              });
+          });
+      });
+
+    new SettingGroup(periodicNotesPanel)
       .setHeading(msg.periodicNotes.sections.daily)
       .addSetting((setting) => {
         setting
@@ -1193,50 +1238,6 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               });
           });
       })
-      .addSetting((setting) => {
-        setting
-          .setName(msg.general.confirmFileCreation.name)
-          .setDesc(msg.general.confirmFileCreation.desc)
-          .addToggle((toggle) => {
-            toggle
-              .setValue(this.plugin.settingsUnderChange.confirmFileCreation)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.confirmFileCreation = value;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
-      })
-      .addSetting((setting) => {
-        setting
-          .setName(msg.periodicNotes.linkDisplayStyle.name)
-          .setDesc(msg.periodicNotes.linkDisplayStyle.desc)
-          .addDropdown((dropdown) => {
-            dropdown
-              .addOptions(threeWayDelimiterOptions)
-              .setValue(this.plugin.settingsUnderChange.periodicNoteLinkDisplayStyle)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.periodicNoteLinkDisplayStyle =
-                  value as ThreeWayDelimiters;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
-      })
-      .addSetting((setting) => {
-        setting
-          .setName(msg.periodicNotes.linkPrefix.name)
-          .setDesc(msg.periodicNotes.linkPrefix.desc)
-          .addText((text) => {
-            text
-              .setValue(this.plugin.settingsUnderChange.periodicNoteLinkPrefix)
-              .onChange((value) => {
-                this.plugin.settingsUnderChange.periodicNoteLinkPrefix = this.plugin.settings
-                  .trimStringsInSettings
-                  ? value.trim()
-                  : value;
-                this.plugin.triggerSettingsChangedDebounced();
-              });
-          });
-      });
 
     new SettingGroup(pinnedContentPanel)
       .addSetting((setting) => {
@@ -1302,25 +1303,23 @@ export class NavLinkHeaderSettingTab extends PluginSettingTab {
               });
           });
       });
-
     const folderLinksSettingsArray = this.plugin.settingsUnderChange.folderLinksSettingsArray;
 
-    const addFolderSettingRow = folderLinksPanel.createDiv();
-    addFolderSettingRow.style.display = "flex";
-    addFolderSettingRow.style.justifyContent = "flex-end";
-    addFolderSettingRow.style.marginBottom = "10px";
+    new SettingGroup(folderLinksPanel).addSetting((setting) => {
+      setting
+        .setName("")
+        .setDesc(msg.folderLinks.intro.desc)
+        .addButton((button) => {
+          button.setButtonText(msg.folderLinks.controls.addFolderSetting).setCta().onClick(() => {
+            this.plugin.settingsUnderChange.folderLinksSettingsArray.push(
+              deepCopy(DEFAULT_FOLDER_LINKS_SETTINGS),
+            );
+            this.plugin.triggerSettingsChangedDebounced();
+            this.display();
+          });
+        });
 
-    const addFolderSettingButton = addFolderSettingRow.createEl("button", {
-      text: msg.folderLinks.controls.addFolderSetting,
-      cls: "mod-cta",
-    });
-    addFolderSettingButton.setAttr("type", "button");
-    addFolderSettingButton.addEventListener("click", () => {
-      this.plugin.settingsUnderChange.folderLinksSettingsArray.push(
-        deepCopy(DEFAULT_FOLDER_LINKS_SETTINGS),
-      );
-      this.plugin.triggerSettingsChangedDebounced();
-      this.display();
+      this.addTipToDescription(setting, msg.folderLinks.intro.tip);
     });
 
     for (let i = 0; i < folderLinksSettingsArray.length; i++) {
@@ -1732,15 +1731,16 @@ class FolderRuleNameModal extends Modal {
       text.inputEl.select();
     });
 
+    const msg = t().modal;
     new Setting(contentEl)
       .addButton((button) => {
-        button.setButtonText("保存").setCta().onClick(() => {
+        button.setButtonText(msg.save).setCta().onClick(() => {
           this.onSubmit(this.value);
           this.close();
         });
       })
       .addButton((button) => {
-        button.setButtonText("取消").onClick(() => {
+        button.setButtonText(msg.cancel).onClick(() => {
           this.close();
         });
       });

--- a/src/ui/CollapsedItem.svelte
+++ b/src/ui/CollapsedItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { CollapsedItemProps } from "./props";
   import Prefix from "./Prefix.svelte";
+  import { t } from "../i18n/i18n";
 
   const { props }: { props: CollapsedItemProps } = $props();
 </script>
@@ -12,7 +13,7 @@
 <div class="nav-link-header-link-container nav-link-header-collapsed-item">
   <Prefix props={props.prefix} />
   <div class="nav-link-header-muted">
-    {`(${props.itemCount} ${props.itemCount === 1 ? "item" : "items"})`}
+    {t().ui.collapsedCount(props.itemCount)}
   </div>
 </div>
 

--- a/src/ui/Navigation.svelte
+++ b/src/ui/Navigation.svelte
@@ -5,6 +5,7 @@
   import PrefixedLink from "./PrefixedLink.svelte";
   import PrefixedMultiLink from "./PrefixedMultiLink.svelte";
   import ThreeWayLink from "./ThreeWayLink.svelte";
+  import { t } from "../i18n/i18n";
 
   const {
     items,
@@ -69,10 +70,10 @@
         {/if}
       {/each}
       {#if isLoading && displayLoadingMessage}
-        <div class="nav-link-header-message nav-link-header-muted">Loading...</div>
+        <div class="nav-link-header-message nav-link-header-muted">{t().ui.loading}</div>
       {/if}
       {#if items.length === 0 && !isLoading && displayPlaceholder}
-        <div class="nav-link-header-message nav-link-header-muted">No links</div>
+        <div class="nav-link-header-message nav-link-header-muted">{t().ui.noLinks}</div>
       {/if}
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -142,3 +142,13 @@
     margin-right: 30px;
   }
 }
+
+/* Tip-style helper text in settings descriptions */
+.nav-link-header-tip-text,
+.header-tip-etxt {
+  display: block;
+  margin-top: 4px;
+  padding-left: 8px;
+  color: var(--text-faint);
+  font-style: italic;
+}


### PR DESCRIPTION

> [!note]
> Most of the changes here were basically done by AI (Claude Opus 4.6). I totally get that there are _way too many_ code changes involved, so if you feel it's risky or not quite right, feel free to just close this PR ;)


## Summary

- Add complete Chinese (zh-CN) localization covering all user-facing strings (settings, commands, modals, navigation UI)
- Redesign settings page with tabbed navigation and improved organization
- Introduce explicit i18n tip/tooltip fields for cleaner supplementary guidance

<img width="1308" height="1144" alt="Snipaste_2026-04-09_19-25-09" src="https://github.com/user-attachments/assets/b40db2d4-71ca-46e4-95c2-ccb21bbbcd52" />

Preview Video:

https://github.com/user-attachments/assets/87858a70-bf8f-4e13-b884-1e8fdbf9f2ba


## Changes

### i18n Framework & Chinese Localization

- New `src/i18n/` directory with type-safe locale system (`types.ts`, `i18n.ts`, `locales/en.ts`, `locales/zh-CN.ts`)
- Language detection via `getLanguage()` (Obsidian 1.8.0+) with `moment.locale()` fallback
- All hardcoded strings replaced with `t()` calls across 7 source files:
  - `settings.ts`: 100+ setting names, descriptions, headings, button texts, dropdown options
  - `commands.ts`: 13 command names
  - `fileCreationModal.ts`: modal title, body, 3 buttons
  - `Navigation.svelte`: "Loading..." / "No links"
  - `CollapsedItem.svelte`: item/items pluralization

### Settings Page Redesign

**Tabbed Navigation**
- Settings split into 7 tabs: Common, Displayed views, Annotated links, Pinned annotations, Property links, Periodic notes, Folder links
- Active tab state preserved across re-renders

**Improved Grouping**
- Original "General" section split into logical groups (common settings + display settings)
- "Displayed views" tab split into "Display positions" (panes/page previews) and view type toggles
- "Periodic notes" organized with sub-headings per granularity (Daily/Weekly/Monthly/Quarterly/Yearly)

**Folder Link Rules**
- Each rule supports collapse/expand with animated chevron icon
- Rule names are click-to-rename (via Obsidian Modal)
- Control buttons (pin to top / move up / move down / remove) aligned to the right on the same row
- "Add folder setting" button placed independently at the top-right

**Tip & Tooltip System**
- Supplementary notes (e.g., "Separate with commas", "Same syntax as...") rendered as dedicated tip text with distinct styling (`font-style: italic`, `color: var(--text-faint)`)
- Special placeholder descriptions (`{periodic}`, `{emojiPlaceholder}`, affected settings list) placed in tooltips (Lucide `info` icon, 16px)
- Tip text driven by explicit i18n `tip` fields (not keyword matching)
- Description text supports line breaks (`white-space: pre-line`)

**Plugin Guide**
- Added a "How to use" section at the top of Common tab with a link to the GitHub repository

### New Files

- `src/i18n/i18n.ts`
- `src/i18n/types.ts`
- `src/i18n/locales/en.ts`
- `src/i18n/locales/zh-CN.ts`

### Modified Files

- `src/settings.ts` — tabbed layout, grouping, folder rule controls, tip/tooltip rendering
- `src/commands.ts` — localized command names
- `src/fileCreationModal.ts` — localized modal strings
- `src/ui/Navigation.svelte` — localized loading/empty states
- `src/ui/CollapsedItem.svelte` — localized collapsed count
- `styles.css` — tip text styling

## Compatibility

- No changes to plugin logic or behavior
- No new dependencies
- Existing settings are fully backward-compatible (new `ruleName` field defaults to empty string)
- `minAppVersion` unchanged (1.11.0)